### PR TITLE
feat: implement fetching and displaying publications from followed and random users on homepage

### DIFF
--- a/social-campus-client/src/components/publicationsList/PublicationsList.jsx
+++ b/social-campus-client/src/components/publicationsList/PublicationsList.jsx
@@ -1,51 +1,24 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Publication from "../publication/Publication";
 import "./PublicationsList.css";
-import useAxiosPrivate from "../../hooks/useAxiosPrivate";
-import { toast } from "react-toastify";
-import Loading from "../loading/Loading";
 
-const USERS_BASE_URL = "/api/users";
-
-function PublicationsList({ userId }) {
-  const axios = useAxiosPrivate();
-  const [publications, setPublications] = useState([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchPublications = async () => {
-      try {
-        setLoading(true);
-        const response = await axios.get(
-          `${USERS_BASE_URL}/${userId.value}/publications`
-        );
-
-        const sortedPublications = response.data.sort((a, b) => {
-          const dateA = new Date(a.creationDateTime);
-          const dateB = new Date(b.creationDateTime);
-          return dateB - dateA;
-        });
-
-        setPublications(sortedPublications);
-      } catch (err) {
-        toast.error(err.message || "Failed to fetch publications");
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchPublications();
-  }, [userId, axios]);
-
-  if (loading) return <Loading />;
-
+function PublicationsList({ publications, lastPublicationRef }) {
   return (
     <div className="publications">
       {publications.length > 0 ? (
-        publications.map((publication) => (
-          <Publication key={publication.id.value} publication={publication} />
-        ))
+        publications.map((publication, index) => {
+          const isLast = index === publications.length - 1;
+
+          return (
+            <div
+              key={publication.id.value}
+              ref={isLast ? lastPublicationRef : null}
+            >
+              <Publication publication={publication} />
+            </div>
+          );
+        })
       ) : (
         <h2 className="no-publications-text general-text">
           No publications yet
@@ -56,9 +29,29 @@ function PublicationsList({ userId }) {
 }
 
 PublicationsList.propTypes = {
-  userId: PropTypes.shape({
-    value: PropTypes.string.isRequired,
-  }).isRequired,
+  publications: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.shape({
+        value: PropTypes.string.isRequired,
+      }).isRequired,
+      description: PropTypes.string.isRequired,
+      imageUrl: PropTypes.string.isRequired,
+      creationDateTime: PropTypes.string.isRequired,
+      creatorId: PropTypes.shape({
+        value: PropTypes.string.isRequired,
+      }).isRequired,
+      userWhoLikedIds: PropTypes.arrayOf(
+        PropTypes.shape({
+          value: PropTypes.string.isRequired,
+        })
+      ),
+      commentsCount: PropTypes.number.isRequired,
+    })
+  ).isRequired,
+  lastPublicationRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.any }),
+  ]),
 };
 
 export default PublicationsList;

--- a/social-campus-client/src/components/publicationsList/PublicationsList.jsx
+++ b/social-campus-client/src/components/publicationsList/PublicationsList.jsx
@@ -3,27 +3,14 @@ import PropTypes from "prop-types";
 import Publication from "../publication/Publication";
 import "./PublicationsList.css";
 
-function PublicationsList({ publications, lastPublicationRef }) {
+function PublicationsList({ publications }) {
   return (
     <div className="publications">
-      {publications.length > 0 ? (
-        publications.map((publication, index) => {
-          const isLast = index === publications.length - 1;
-
-          return (
-            <div
-              key={publication.id.value}
-              ref={isLast ? lastPublicationRef : null}
-            >
-              <Publication publication={publication} />
-            </div>
-          );
-        })
-      ) : (
-        <h2 className="no-publications-text general-text">
-          No publications yet
-        </h2>
-      )}
+      {publications.map((publication) => (
+        <div key={publication.id.value}>
+          <Publication publication={publication} />
+        </div>
+      ))}
     </div>
   );
 }
@@ -48,10 +35,6 @@ PublicationsList.propTypes = {
       commentsCount: PropTypes.number.isRequired,
     })
   ).isRequired,
-  lastPublicationRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.any }),
-  ]),
 };
 
 export default PublicationsList;

--- a/social-campus-client/src/pages/home/Home.css
+++ b/social-campus-client/src/pages/home/Home.css
@@ -1,0 +1,5 @@
+.load-more-container {
+  display: flex;
+  justify-content: center;
+  margin: 10px;
+}

--- a/social-campus-client/src/pages/home/Home.jsx
+++ b/social-campus-client/src/pages/home/Home.jsx
@@ -1,22 +1,81 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import PublicationsList from "../../components/publicationsList/PublicationsList";
+import useAxiosPrivate from "../../hooks/useAxiosPrivate";
+import useAuth from "../../hooks/useAuth";
+import Loading from "../../components/loading/Loading";
+
+const GET_HOME_PAGE_PUBLICATIONS_BASE_URL = "/api/publications/home/user";
 
 function Home() {
+  const axios = useAxiosPrivate();
+  const { auth } = useAuth();
+
   const [publications, setPublications] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [hasMore, setHasMore] = useState(true);
 
-  useEffect(() => {}, []);
+  const observer = useRef();
 
-  if (publications.length === 0) {
-    return (
-      <h1 className="no-publications-text general-text">
-        No followed publications found
-      </h1>
-    );
-  }
+  const lastPublicationRef = useCallback(
+    (node) => {
+      if (loading) return;
+
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting && hasMore) {
+          fetchPublications();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [loading, hasMore]
+  );
+
+  const fetchPublications = async () => {
+    setLoading(true);
+    try {
+      const userId = auth?.shortUser?.id.value;
+      const limit = 2;
+      const last = publications[publications.length - 1];
+      const lastId = last?.id.value;
+
+      const url = lastId
+        ? `${GET_HOME_PAGE_PUBLICATIONS_BASE_URL}/${userId}/${limit}?lastPublicationId=${lastId}`
+        : `${GET_HOME_PAGE_PUBLICATIONS_BASE_URL}/${userId}/${limit}`;
+
+      const response = await axios.get(url);
+
+      const newPublications = response.data;
+
+      setPublications((prev) => [...prev, ...newPublications]);
+      setHasMore(newPublications.length === limit);
+    } catch (error) {
+      console.error("Error fetching publications:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPublications();
+  }, []);
 
   return (
     <div className="home">
-      <PublicationsList publications={publications} />
+      {publications.length === 0 && !loading ? (
+        <h1 className="no-publications-text general-text">
+          No followed publications found
+        </h1>
+      ) : (
+        <PublicationsList
+          publications={publications}
+          lastPublicationRef={lastPublicationRef}
+        />
+      )}
+
+      {loading && <Loading />}
     </div>
   );
 }

--- a/social-campus-client/src/pages/home/Home.jsx
+++ b/social-campus-client/src/pages/home/Home.jsx
@@ -1,56 +1,36 @@
-import React, { useState, useEffect, useRef, useCallback } from "react";
+import React, { useState, useEffect } from "react";
 import PublicationsList from "../../components/publicationsList/PublicationsList";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
 import useAuth from "../../hooks/useAuth";
 import Loading from "../../components/loading/Loading";
+import "./Home.css";
 
 const GET_HOME_PAGE_PUBLICATIONS_BASE_URL = "/api/publications/home/user";
+const PAGE_SIZE = 10;
 
 function Home() {
   const axios = useAxiosPrivate();
   const { auth } = useAuth();
 
+  const [page, setPage] = useState(1);
   const [publications, setPublications] = useState([]);
-  const [loading, setLoading] = useState(false);
-  const [hasMore, setHasMore] = useState(true);
-
-  const observer = useRef();
-
-  const lastPublicationRef = useCallback(
-    (node) => {
-      if (loading) return;
-
-      if (observer.current) observer.current.disconnect();
-
-      observer.current = new IntersectionObserver((entries) => {
-        if (entries[0].isIntersecting && hasMore) {
-          fetchPublications();
-        }
-      });
-
-      if (node) observer.current.observe(node);
-    },
-    [loading, hasMore]
-  );
+  const [loading, setLoading] = useState(true);
+  const [allFetched, setAllFetched] = useState(false);
 
   const fetchPublications = async () => {
-    setLoading(true);
     try {
-      const userId = auth?.shortUser?.id.value;
-      const limit = 2;
-      const last = publications[publications.length - 1];
-      const lastId = last?.id.value;
-
-      const url = lastId
-        ? `${GET_HOME_PAGE_PUBLICATIONS_BASE_URL}/${userId}/${limit}?lastPublicationId=${lastId}`
-        : `${GET_HOME_PAGE_PUBLICATIONS_BASE_URL}/${userId}/${limit}`;
-
-      const response = await axios.get(url);
-
+      const response = await axios.get(
+        `${GET_HOME_PAGE_PUBLICATIONS_BASE_URL}/${auth.shortUser.id.value}/count/${PAGE_SIZE}/page/${page}`
+      );
       const newPublications = response.data;
 
+      if (newPublications.length === 0) {
+        setAllFetched(true);
+        return;
+      }
+
       setPublications((prev) => [...prev, ...newPublications]);
-      setHasMore(newPublications.length === limit);
+      setPage((prev) => prev + 1);
     } catch (error) {
       console.error("Error fetching publications:", error);
     } finally {
@@ -62,20 +42,24 @@ function Home() {
     fetchPublications();
   }, []);
 
+  if (loading && publications.length === 0) {
+    return <Loading />;
+  }
+
   return (
     <div className="home">
-      {publications.length === 0 && !loading ? (
-        <h1 className="no-publications-text general-text">
-          No followed publications found
-        </h1>
+      {publications.length === 0 ? (
+        <p className="no-publications-text">No publications found</p>
       ) : (
-        <PublicationsList
-          publications={publications}
-          lastPublicationRef={lastPublicationRef}
-        />
+        <>
+          <PublicationsList publications={publications} />
+          {!allFetched && (
+            <div className="load-more-container">
+              <button onClick={fetchPublications}>Load More</button>
+            </div>
+          )}
+        </>
       )}
-
-      {loading && <Loading />}
     </div>
   );
 }

--- a/social-campus-client/src/pages/profile/Profile.jsx
+++ b/social-campus-client/src/pages/profile/Profile.jsx
@@ -70,7 +70,7 @@ function Profile() {
       setAllFetched(false);
       fetchPublications();
     }
-  }, [user]);
+  }, [user, login]);
 
   if (loadingUser) {
     return (

--- a/social-campus-server/Application/PublicationLikes/Commands/AddPublicationLike/AddPublicationLikeCommandHandler.cs
+++ b/social-campus-server/Application/PublicationLikes/Commands/AddPublicationLike/AddPublicationLikeCommandHandler.cs
@@ -5,7 +5,7 @@ using Domain.Shared;
 namespace Application.PublicationLikes.Commands.AddPublicationLike;
 
 public class AddPublicationLikeCommandHandler(
-    IPublicationLikeRepositories publicationLikeRepositories,
+    IPublicationLikeRepository publicationLikeRepository,
     IUserRepository userRepository,
     IPublicationRepository publicationRepository) : ICommandHandler<AddPublicationLikeCommand>
 {
@@ -23,13 +23,13 @@ public class AddPublicationLikeCommandHandler(
                 "Publication.NotFound",
                 $"Publication with PublicationId {request.PublicationId.Value} was not found"));
 
-        var isAlreadiAddLike = await publicationLikeRepositories.IsLike(request.UserId, request.PublicationId);
+        var isAlreadiAddLike = await publicationLikeRepository.IsLike(request.UserId, request.PublicationId);
         if (isAlreadiAddLike)
             return Result.Failure(new Error(
                 "PublicationLike.AlreadyAddLike",
                 $"User with UserId {request.UserId.Value} already add like to publication with PublicationId {request.PublicationId.Value}"));
 
-        await publicationLikeRepositories.AddAsync(request.UserId, request.PublicationId);
+        await publicationLikeRepository.AddAsync(request.UserId, request.PublicationId);
 
         return Result.Success();
     }

--- a/social-campus-server/Application/PublicationLikes/Commands/RemovePublicationLike/RemovePublicationLikeCommandHandler.cs
+++ b/social-campus-server/Application/PublicationLikes/Commands/RemovePublicationLike/RemovePublicationLikeCommandHandler.cs
@@ -7,7 +7,7 @@ namespace Application.PublicationLikes.Commands.RemovePublicationLike;
 public class RemovePublicationLikeCommandHandler(
     IUserRepository userRepository,
     IPublicationRepository publicationRepository,
-    IPublicationLikeRepositories publicationLikeRepositories) : ICommandHandler<RemovePublicationLikeCommand>
+    IPublicationLikeRepository publicationLikeRepository) : ICommandHandler<RemovePublicationLikeCommand>
 {
     public async Task<Result> Handle(RemovePublicationLikeCommand request, CancellationToken cancellationToken)
     {
@@ -23,13 +23,13 @@ public class RemovePublicationLikeCommandHandler(
                 "Publication.NotFound",
                 $"Publication with PublicationId {request.PublicationId.Value} was not found"));
 
-        var isAlreadiAddLike = await publicationLikeRepositories.IsLike(request.UserId, request.PublicationId);
+        var isAlreadiAddLike = await publicationLikeRepository.IsLike(request.UserId, request.PublicationId);
         if (!isAlreadiAddLike)
             return Result.Failure(new Error(
                 "PublicationLike.NotAddLikeYet",
                 $"User with UserId {request.UserId.Value} was not add like to publication with PublicationId {request.PublicationId.Value}"));
 
-        await publicationLikeRepositories.DeleteAsync(request.UserId, request.PublicationId);
+        await publicationLikeRepository.DeleteAsync(request.UserId, request.PublicationId);
 
         return Result.Success();
     }

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQuery.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQuery.cs
@@ -1,0 +1,9 @@
+using Application.Abstractions.Messaging;
+using Application.Dtos;
+using Domain.Models.PublicationModel;
+using Domain.Models.UserModel;
+
+namespace Application.Publications.Queries.GetHomePagePublications;
+
+public record GetHomePagePublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Limit)
+    : IQuery<IReadOnlyList<PublicationDto>>;

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQuery.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQuery.cs
@@ -5,5 +5,5 @@ using Domain.Models.UserModel;
 
 namespace Application.Publications.Queries.GetHomePagePublications;
 
-public record GetHomePagePublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Limit)
+public record GetHomePagePublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Count)
     : IQuery<IReadOnlyList<PublicationDto>>;

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQuery.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQuery.cs
@@ -5,5 +5,5 @@ using Domain.Models.UserModel;
 
 namespace Application.Publications.Queries.GetHomePagePublications;
 
-public record GetHomePagePublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Count)
+public record GetHomePagePublicationsQuery(UserId UserId, int Page, int Count)
     : IQuery<IReadOnlyList<PublicationDto>>;

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
@@ -1,0 +1,68 @@
+using Application.Abstractions.Messaging;
+using Application.Dtos;
+using Domain.Abstractions.Repositories;
+using Domain.Models.PublicationModel;
+using Domain.Shared;
+
+namespace Application.Publications.Queries.GetHomePagePublications;
+
+public class GetHomePagePublicationsQueryHandler(
+    IUserRepository userRepository,
+    IPublicationRepository publicationRepository,
+    IFollowRepository followRepository,
+    ICommentRepository commentRepository,
+    IPublicationLikeRepository publicationLikeRepository)
+    : IQueryHandler<GetHomePagePublicationsQuery, IReadOnlyList<PublicationDto>>
+{
+    public async Task<Result<IReadOnlyList<PublicationDto>>> Handle(GetHomePagePublicationsQuery request,
+        CancellationToken cancellationToken)
+    {
+        var user = await userRepository.GetByIdAsync(request.UserId);
+        if (user is null)
+            return Result.Failure<IReadOnlyList<PublicationDto>>(new Error(
+                "User.NotFound",
+                $"User with UserId {request.UserId.Value} was not found"));
+
+        Publication? lastPublication = null;
+        if (request.LastPublicationId is not null)
+        {
+            lastPublication = await publicationRepository.GetByIdAsync(request.LastPublicationId);
+            if (lastPublication is null)
+                return Result.Failure<IReadOnlyList<PublicationDto>>(new Error(
+                    "Publication.NotFound",
+                    $"Publication with PublicationId {request.LastPublicationId.Value} was not found"));
+        }
+
+        var followedUsers = await followRepository.GetFollowingUsersByUserIdAsync(user.Id);
+
+        var homePagePublications = await publicationRepository.GetPublicationsForHomePageAsync(
+            followedUsers,
+            lastPublication,
+            request.Limit,
+            user
+        );
+
+        var homePagePublicationsDtos = new List<PublicationDto>();
+        foreach (var publication in homePagePublications)
+        {
+            var publicationLikes = await publicationLikeRepository
+                .GetPublicationLikesListByPublicationIdAsync(publication.Id);
+
+            var comments = await commentRepository
+                .GetPublicationCommentsByPublicationIdAsync(publication.Id);
+
+            homePagePublicationsDtos.Add(new PublicationDto
+            {
+                Id = publication.Id,
+                Description = publication.Description,
+                ImageUrl = publication.ImageUrl,
+                CreationDateTime = publication.CreationDateTime,
+                CreatorId = user.Id,
+                UserWhoLikedIds = publicationLikes.Select(like => like.UserId).ToList(),
+                CommentsCount = comments.Count
+            });
+        }
+
+        return Result.Success<IReadOnlyList<PublicationDto>>(homePagePublicationsDtos);
+    }
+}

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
@@ -23,21 +23,12 @@ public class GetHomePagePublicationsQueryHandler(
                 "User.NotFound",
                 $"User with UserId {request.UserId.Value} was not found"));
 
-        Publication? lastPublication = null;
-        if (request.LastPublicationId is not null)
-        {
-            lastPublication = await publicationRepository.GetByIdAsync(request.LastPublicationId);
-            if (lastPublication is null)
-                return Result.Failure<IReadOnlyList<PublicationDto>>(new Error(
-                    "Publication.NotFound",
-                    $"Publication with PublicationId {request.LastPublicationId.Value} was not found"));
-        }
 
         var followedUsers = await followRepository.GetFollowingUsersByUserIdAsync(user.Id);
 
         var homePagePublications = await publicationRepository.GetPublicationsForHomePageAsync(
             followedUsers,
-            lastPublication,
+            request.Page,
             request.Count,
             user
         );

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
@@ -57,7 +57,7 @@ public class GetHomePagePublicationsQueryHandler(
                 Description = publication.Description,
                 ImageUrl = publication.ImageUrl,
                 CreationDateTime = publication.CreationDateTime,
-                CreatorId = user.Id,
+                CreatorId = publication.CreatorId,
                 UserWhoLikedIds = publicationLikes.Select(like => like.UserId).ToList(),
                 CommentsCount = comments.Count
             });

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryHandler.cs
@@ -38,7 +38,7 @@ public class GetHomePagePublicationsQueryHandler(
         var homePagePublications = await publicationRepository.GetPublicationsForHomePageAsync(
             followedUsers,
             lastPublication,
-            request.Limit,
+            request.Count,
             user
         );
 

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryValidator.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryValidator.cs
@@ -13,10 +13,10 @@ public class GetHomePagePublicationsQueryValidator : AbstractValidator<GetHomePa
         RuleFor(f => f.LastPublicationId)
             .Must(id => id == null || id.Value != Guid.Empty).WithMessage("PublicationId must be a valid GUID");
 
-        RuleFor(x => x.Limit)
+        RuleFor(x => x.Count)
             .GreaterThan(0)
-            .WithMessage("Limit must be greater than 0.")
+            .WithMessage("Count must be greater than 0.")
             .LessThanOrEqualTo(100)
-            .WithMessage("Limit must be 100 or less.");
+            .WithMessage("Count must be 100 or less.");
     }
 }

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryValidator.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryValidator.cs
@@ -10,8 +10,9 @@ public class GetHomePagePublicationsQueryValidator : AbstractValidator<GetHomePa
             .NotEmpty().WithMessage("UserId is required")
             .Must(id => id.Value != Guid.Empty).WithMessage("UserId must be a valid GUID");
 
-        RuleFor(f => f.LastPublicationId)
-            .Must(id => id == null || id.Value != Guid.Empty).WithMessage("PublicationId must be a valid GUID");
+        RuleFor(f => f.Page)
+            .GreaterThan(0)
+            .WithMessage("Count must be greater than 0.");
 
         RuleFor(x => x.Count)
             .GreaterThan(0)

--- a/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryValidator.cs
+++ b/social-campus-server/Application/Publications/Queries/GetHomePagePublications/GetHomePagePublicationsQueryValidator.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+
+namespace Application.Publications.Queries.GetHomePagePublications;
+
+public class GetHomePagePublicationsQueryValidator : AbstractValidator<GetHomePagePublicationsQuery>
+{
+    public GetHomePagePublicationsQueryValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty().WithMessage("UserId is required")
+            .Must(id => id.Value != Guid.Empty).WithMessage("UserId must be a valid GUID");
+
+        RuleFor(f => f.LastPublicationId)
+            .Must(id => id == null || id.Value != Guid.Empty).WithMessage("PublicationId must be a valid GUID");
+
+        RuleFor(x => x.Limit)
+            .GreaterThan(0)
+            .WithMessage("Limit must be greater than 0.")
+            .LessThanOrEqualTo(100)
+            .WithMessage("Limit must be 100 or less.");
+    }
+}

--- a/social-campus-server/Application/Publications/Queries/GetPublication/GetPublicationQueryHandler.cs
+++ b/social-campus-server/Application/Publications/Queries/GetPublication/GetPublicationQueryHandler.cs
@@ -7,7 +7,7 @@ namespace Application.Publications.Queries.GetPublication;
 
 public class GetPublicationQueryHandler(
     IPublicationRepository publicationRepository,
-    IPublicationLikeRepositories publicationLikeRepositories,
+    IPublicationLikeRepository publicationLikeRepository,
     ICommentRepository commentRepository) : IQueryHandler<GetPublicationQuery, PublicationDto>
 {
     public async Task<Result<PublicationDto>> Handle(GetPublicationQuery request, CancellationToken cancellationToken)
@@ -18,7 +18,7 @@ public class GetPublicationQueryHandler(
                 "Publication.NotFound",
                 $"Publication with PublicationId {request.PublicationId.Value} was not found"));
 
-        var publicationLikes = await publicationLikeRepositories
+        var publicationLikes = await publicationLikeRepository
             .GetPublicationLikesListByPublicationIdAsync(publication.Id);
         var comments = await commentRepository.GetPublicationCommentsByPublicationIdAsync(publication.Id);
 

--- a/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQuery.cs
+++ b/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQuery.cs
@@ -1,7 +1,9 @@
 using Application.Abstractions.Messaging;
 using Application.Dtos;
+using Domain.Models.PublicationModel;
 using Domain.Models.UserModel;
 
 namespace Application.Users.Queries.GetUserPublications;
 
-public record GetUserPublicationsQuery(UserId UserId) : IQuery<IReadOnlyList<PublicationDto>>;
+public record GetUserPublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Limit)
+    : IQuery<IReadOnlyList<PublicationDto>>;

--- a/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQuery.cs
+++ b/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQuery.cs
@@ -5,5 +5,5 @@ using Domain.Models.UserModel;
 
 namespace Application.Users.Queries.GetUserPublications;
 
-public record GetUserPublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Limit)
+public record GetUserPublicationsQuery(UserId UserId, PublicationId? LastPublicationId, int Count)
     : IQuery<IReadOnlyList<PublicationDto>>;

--- a/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryHandler.cs
+++ b/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryHandler.cs
@@ -8,7 +8,7 @@ namespace Application.Users.Queries.GetUserPublications;
 public class GetUserPublicationsQueryHandler(
     IPublicationRepository publicationRepository,
     IUserRepository userRepository,
-    IPublicationLikeRepositories publicationLikeRepositories,
+    IPublicationLikeRepository publicationLikeRepository,
     ICommentRepository commentRepository)
     : IQueryHandler<GetUserPublicationsQuery, IReadOnlyList<PublicationDto>>
 {
@@ -26,7 +26,7 @@ public class GetUserPublicationsQueryHandler(
         var publicationDtos = new List<PublicationDto>();
         foreach (var publication in userPublications)
         {
-            var publicationLikes = await publicationLikeRepositories
+            var publicationLikes = await publicationLikeRepository
                 .GetPublicationLikesListByPublicationIdAsync(publication.Id);
 
             var comments = await commentRepository

--- a/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryHandler.cs
+++ b/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryHandler.cs
@@ -35,7 +35,7 @@ public class GetUserPublicationsQueryHandler(
         var userPublications = await publicationRepository.GetUserPublicationsByUserIdAsync(
             user.Id,
             lastPublication,
-            request.Limit);
+            request.Count);
 
         var publicationDtos = new List<PublicationDto>();
         foreach (var publication in userPublications)

--- a/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryValidator.cs
+++ b/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryValidator.cs
@@ -9,5 +9,14 @@ public class GetUserPublicationsQueryValidator : AbstractValidator<GetUserPublic
         RuleFor(f => f.UserId)
             .NotEmpty().WithMessage("UserId is required")
             .Must(id => id.Value != Guid.Empty).WithMessage("UserId must be a valid GUID");
+
+        RuleFor(f => f.LastPublicationId)
+            .Must(id => id == null || id.Value != Guid.Empty).WithMessage("PublicationId must be a valid GUID");
+
+        RuleFor(x => x.Limit)
+            .GreaterThan(0)
+            .WithMessage("Limit must be greater than 0.")
+            .LessThanOrEqualTo(100)
+            .WithMessage("Limit must be 100 or less.");
     }
 }

--- a/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryValidator.cs
+++ b/social-campus-server/Application/Users/Queries/GetUserPublications/GetUserPublicationsQueryValidator.cs
@@ -13,10 +13,10 @@ public class GetUserPublicationsQueryValidator : AbstractValidator<GetUserPublic
         RuleFor(f => f.LastPublicationId)
             .Must(id => id == null || id.Value != Guid.Empty).WithMessage("PublicationId must be a valid GUID");
 
-        RuleFor(x => x.Limit)
+        RuleFor(x => x.Count)
             .GreaterThan(0)
-            .WithMessage("Limit must be greater than 0.")
+            .WithMessage("Count must be greater than 0.")
             .LessThanOrEqualTo(100)
-            .WithMessage("Limit must be 100 or less.");
+            .WithMessage("Count must be 100 or less.");
     }
 }

--- a/social-campus-server/Domain/Abstractions/Repositories/IPublicationLikeRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IPublicationLikeRepository.cs
@@ -4,7 +4,7 @@ using Domain.Models.UserModel;
 
 namespace Domain.Abstractions.Repositories;
 
-public interface IPublicationLikeRepositories
+public interface IPublicationLikeRepository
 {
     public Task AddAsync(UserId userId, PublicationId publicationId);
     public Task DeleteAsync(UserId userId, PublicationId publicationId);

--- a/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
@@ -16,5 +16,5 @@ public interface IPublicationRepository
     public Task<bool> IsExistByIdAsync(PublicationId publicationId);
 
     public Task<IReadOnlyList<Publication>> GetPublicationsForHomePageAsync(IReadOnlyList<User> followedUsers,
-        Publication? lastPublication, int count, User currentUser);
+        int page, int count, User currentUser);
 }

--- a/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
@@ -10,11 +10,11 @@ public interface IPublicationRepository
     public Task<Publication?> GetByIdAsync(PublicationId publicationId);
 
     public Task<IReadOnlyList<Publication>> GetUserPublicationsByUserIdAsync(UserId creatorId,
-        Publication? lastPublication, int limit);
+        Publication? lastPublication, int count);
 
     public void Update(Publication publication, string description, string imageData);
     public Task<bool> IsExistByIdAsync(PublicationId publicationId);
 
     public Task<IReadOnlyList<Publication>> GetPublicationsForHomePageAsync(IReadOnlyList<User> followedUsers,
-        Publication? lastPublication, int limit, User currentUser);
+        Publication? lastPublication, int count, User currentUser);
 }

--- a/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
@@ -8,7 +8,10 @@ public interface IPublicationRepository
 {
     public Task AddAsync(string description, UserId creatorId, string imageData);
     public Task<Publication?> GetByIdAsync(PublicationId publicationId);
-    public Task<IReadOnlyList<Publication>> GetUserPublicationsByUserIdAsync(UserId creatorId);
+
+    public Task<IReadOnlyList<Publication>> GetUserPublicationsByUserIdAsync(UserId creatorId,
+        Publication? lastPublication, int limit);
+
     public void Update(Publication publication, string description, string imageData);
     public Task<bool> IsExistByIdAsync(PublicationId publicationId);
 

--- a/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IPublicationRepository.cs
@@ -1,4 +1,5 @@
-﻿using Domain.Models.PublicationModel;
+﻿using Domain.Models.FollowModel;
+using Domain.Models.PublicationModel;
 using Domain.Models.UserModel;
 
 namespace Domain.Abstractions.Repositories;
@@ -10,4 +11,7 @@ public interface IPublicationRepository
     public Task<IReadOnlyList<Publication>> GetUserPublicationsByUserIdAsync(UserId creatorId);
     public void Update(Publication publication, string description, string imageData);
     public Task<bool> IsExistByIdAsync(PublicationId publicationId);
+
+    public Task<IReadOnlyList<Publication>> GetPublicationsForHomePageAsync(IReadOnlyList<User> followedUsers,
+        Publication? lastPublication, int limit, User currentUser);
 }

--- a/social-campus-server/Infrastructure/DependencyInjection.cs
+++ b/social-campus-server/Infrastructure/DependencyInjection.cs
@@ -44,7 +44,7 @@ public static class DependencyInjection
         services.AddScoped<IUnitOfWork, UnitOfWork>();
         services.AddScoped<IFollowRepository, FollowRepository>();
         services.AddScoped<IPublicationRepository, PublicationRepository>();
-        services.AddScoped<IPublicationLikeRepositories, PublicationLikeRepositories>();
+        services.AddScoped<IPublicationLikeRepository, PublicationLikeRepository>();
         services.AddScoped<ICommentRepository, CommentRepository>();
         services.AddScoped<ICommentLikeRepository, CommentLikeRepository>();
 

--- a/social-campus-server/Infrastructure/DependencyInjection.cs
+++ b/social-campus-server/Infrastructure/DependencyInjection.cs
@@ -25,20 +25,6 @@ public static class DependencyInjection
             options.UseSqlServer(configuration.GetConnectionString("LocalConnection"))
                 .UseAsyncSeeding(async (context, _, ct) => await DatabaseSeeder.SeedAsync(context, services, ct)));
 
-        services.AddAuthorization();
-        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
-            .AddJwtBearer(o => o.TokenValidationParameters = new TokenValidationParameters
-            {
-                ValidateIssuer = true,
-                ValidateAudience = true,
-                ValidateLifetime = true,
-                ValidateIssuerSigningKey = true,
-                ValidIssuer = configuration["Jwt:Issuer"],
-                ValidAudience = configuration["Jwt:Audience"],
-                IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:SecretKey"]!)),
-                ClockSkew = TimeSpan.Zero
-            });
-
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddScoped<IRefreshTokenRepository, RefreshTokenRepository>();
         services.AddScoped<IUnitOfWork, UnitOfWork>();

--- a/social-campus-server/Infrastructure/Repositories/PublicationLikeRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/PublicationLikeRepository.cs
@@ -7,8 +7,8 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Infrastructure.Repositories;
 
-public class PublicationLikeRepositories(
-    ApplicationDbContext context) : IPublicationLikeRepositories
+public class PublicationLikeRepository(
+    ApplicationDbContext context) : IPublicationLikeRepository
 {
     public async Task AddAsync(UserId userId, PublicationId publicationId)
     {

--- a/social-campus-server/Infrastructure/Repositories/PublicationRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/PublicationRepository.cs
@@ -8,7 +8,7 @@ namespace Infrastructure.Repositories;
 
 public class PublicationRepository(ApplicationDbContext context) : IPublicationRepository
 {
-    private static readonly Random _random = new();
+    private static readonly Random Random = new();
 
     public async Task AddAsync(string description, UserId creatorId, string imageData)
     {
@@ -20,7 +20,7 @@ public class PublicationRepository(ApplicationDbContext context) : IPublicationR
     public async Task<IReadOnlyList<Publication>> GetUserPublicationsByUserIdAsync(
         UserId creatorId,
         Publication? lastPublication,
-        int limit)
+        int count)
     {
         var query = context.Publications
             .Where(p => p.CreatorId == creatorId);
@@ -29,7 +29,7 @@ public class PublicationRepository(ApplicationDbContext context) : IPublicationR
 
         return await query
             .OrderByDescending(p => p.CreationDateTime)
-            .Take(limit)
+            .Take(count)
             .ToListAsync();
     }
 
@@ -53,16 +53,16 @@ public class PublicationRepository(ApplicationDbContext context) : IPublicationR
     public async Task<IReadOnlyList<Publication>> GetPublicationsForHomePageAsync(
         IReadOnlyList<User> followedUsers,
         Publication? lastPublication,
-        int limit,
+        int count,
         User currentUser)
     {
         var userIds = followedUsers.Select(u => u.Id).ToHashSet();
         userIds.Add(currentUser.Id);
 
-        var randomPart = _random.NextDouble() * 0.5;
-        var randomCount = (int)(limit * randomPart);
-        randomCount = Math.Min(randomCount, limit);
-        var followedCountLimit = limit - randomCount;
+        var randomPart = Random.NextDouble() * 0.5;
+        var randomCount = (int)(count * randomPart);
+        randomCount = Math.Min(randomCount, count);
+        var followedCountLimit = count - randomCount;
 
         var followedQuery = context.Publications
             .Where(p => userIds.Contains(p.CreatorId));
@@ -75,7 +75,7 @@ public class PublicationRepository(ApplicationDbContext context) : IPublicationR
             .Take(followedCountLimit)
             .ToListAsync();
 
-        var needCount = limit - followingPublications.Count;
+        var needCount = count - followingPublications.Count;
         if (needCount > 0)
         {
             var randomPublicationsQuery = context.Publications
@@ -90,7 +90,7 @@ public class PublicationRepository(ApplicationDbContext context) : IPublicationR
                 .ToListAsync();
 
             randomPublications = randomPublications
-                .OrderBy(_ => _random.Next())
+                .OrderBy(_ => Random.Next())
                 .Take(needCount)
                 .ToList();
 
@@ -99,7 +99,7 @@ public class PublicationRepository(ApplicationDbContext context) : IPublicationR
 
         return followingPublications
             .OrderByDescending(p => p.CreationDateTime)
-            .Take(limit)
+            .Take(count)
             .ToList();
     }
 }

--- a/social-campus-server/Presentation/DependencyInjection.cs
+++ b/social-campus-server/Presentation/DependencyInjection.cs
@@ -1,0 +1,41 @@
+using System.Reflection;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Presentation.Extensions;
+
+namespace Presentation;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddPresentation(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddAuthorization();
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+            .AddJwtBearer(o => o.TokenValidationParameters = new TokenValidationParameters
+            {
+                ValidateIssuer = true,
+                ValidateAudience = true,
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidIssuer = configuration["Jwt:Issuer"],
+                ValidAudience = configuration["Jwt:Audience"],
+                IssuerSigningKey =
+                    new SymmetricSecurityKey(Encoding.UTF8.GetBytes(configuration["Jwt:SecretKey"]!)),
+                ClockSkew = TimeSpan.Zero
+            });
+
+        services.AddOpenApi(options => { options.AddDocumentTransformer<OpenApiExtension>(); });
+
+        services.AddEndpoints(Assembly.GetExecutingAssembly());
+        services.AddClientCors(
+            "ClientCors",
+            [
+                "http://localhost:3000",
+                "https://localhost:3000"
+            ]
+        );
+
+        return services;
+    }
+}

--- a/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
@@ -11,7 +11,7 @@ public class GetHomePagePublicationsByUserIdEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("publications/home/{userId:guid}/{limit:int}", async (
+        app.MapGet("publications/home/user/{userId:guid}/{limit:int}", async (
                 Guid userId,
                 int limit,
                 Guid? lastPublicationId,

--- a/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
@@ -11,16 +11,16 @@ public class GetHomePagePublicationsByUserIdEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("publications/home/user/{userId:guid}/{limit:int}", async (
+        app.MapGet("publications/home/user/{userId:guid}/{count:int}", async (
                 Guid userId,
-                int limit,
+                int count,
                 Guid? lastPublicationId,
                 ISender sender) =>
             {
                 var query = new GetHomePagePublicationsQuery(
                     new UserId(userId),
                     lastPublicationId is not null ? new PublicationId(lastPublicationId.Value) : null,
-                    limit);
+                    count);
 
                 var response = await sender.Send(query);
 

--- a/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
@@ -1,0 +1,32 @@
+using Application.Publications.Queries.GetHomePagePublications;
+using Domain.Models.PublicationModel;
+using Domain.Models.UserModel;
+using MediatR;
+using Presentation.Abstractions;
+using Presentation.Consts;
+
+namespace Presentation.Endpoints.Publications.GetHomePagePublicationsByUserId;
+
+public class GetHomePagePublicationsByUserIdEndpoint : BaseEndpoint, IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("publications/home/{userId:guid}/{limit:int}", async (
+                Guid userId,
+                int limit,
+                Guid? lastPublicationId,
+                ISender sender) =>
+            {
+                var query = new GetHomePagePublicationsQuery(
+                    new UserId(userId),
+                    lastPublicationId is not null ? new PublicationId(lastPublicationId.Value) : null,
+                    limit);
+
+                var response = await sender.Send(query);
+
+                return response.IsSuccess ? Results.Ok(response.Value) : HandleFailure(response);
+            })
+            .WithTags(Tags.Publications)
+            .RequireAuthorization();
+    }
+}

--- a/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Publications/GetHomePagePublicationsByUserId/GetHomePagePublicationsByUserIdEndpoint.cs
@@ -11,15 +11,15 @@ public class GetHomePagePublicationsByUserIdEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("publications/home/user/{userId:guid}/{count:int}", async (
+        app.MapGet("publications/home/user/{userId:guid}/count/{count:int}/page/{page:int}", async (
                 Guid userId,
                 int count,
-                Guid? lastPublicationId,
+                int page,
                 ISender sender) =>
             {
                 var query = new GetHomePagePublicationsQuery(
                     new UserId(userId),
-                    lastPublicationId is not null ? new PublicationId(lastPublicationId.Value) : null,
+                    page,
                     count);
 
                 var response = await sender.Send(query);

--- a/social-campus-server/Presentation/Endpoints/Users/GetUserPublications/GetUserPublicationsEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Users/GetUserPublications/GetUserPublicationsEndpoint.cs
@@ -11,12 +11,12 @@ public class GetUserPublicationsEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("/users/{userId:guid:required}/publications/{limit:int}",
-                async (ISender sender, Guid userId, int limit, Guid? lastPublicationId) =>
+        app.MapGet("/users/{userId:guid:required}/publications/{count:int}",
+                async (ISender sender, Guid userId, int count, Guid? lastPublicationId) =>
                 {
                     GetUserPublicationsQuery queryRequest =
                         new(new UserId(userId),
-                            lastPublicationId is not null ? new PublicationId(lastPublicationId.Value) : null, limit);
+                            lastPublicationId is not null ? new PublicationId(lastPublicationId.Value) : null, count);
 
                     var response = await sender.Send(queryRequest);
 

--- a/social-campus-server/Presentation/Endpoints/Users/GetUserPublications/GetUserPublicationsEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Users/GetUserPublications/GetUserPublicationsEndpoint.cs
@@ -1,4 +1,5 @@
 using Application.Users.Queries.GetUserPublications;
+using Domain.Models.PublicationModel;
 using Domain.Models.UserModel;
 using MediatR;
 using Presentation.Abstractions;
@@ -10,14 +11,17 @@ public class GetUserPublicationsEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("/users/{userId:guid:required}/publications", async (ISender sender, Guid userId) =>
-            {
-                GetUserPublicationsQuery queryRequest = new(new UserId(userId));
+        app.MapGet("/users/{userId:guid:required}/publications/{limit:int}",
+                async (ISender sender, Guid userId, int limit, Guid? lastPublicationId) =>
+                {
+                    GetUserPublicationsQuery queryRequest =
+                        new(new UserId(userId),
+                            lastPublicationId is not null ? new PublicationId(lastPublicationId.Value) : null, limit);
 
-                var response = await sender.Send(queryRequest);
+                    var response = await sender.Send(queryRequest);
 
-                return response.IsSuccess ? Results.Ok(response.Value) : HandleFailure(response);
-            })
+                    return response.IsSuccess ? Results.Ok(response.Value) : HandleFailure(response);
+                })
             .WithTags(Tags.Users)
             .RequireAuthorization();
     }

--- a/social-campus-server/Presentation/Endpoints/Users/GetUserPublications/GetUserPublicationsEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Users/GetUserPublications/GetUserPublicationsEndpoint.cs
@@ -11,7 +11,7 @@ public class GetUserPublicationsEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("/users/{userId:guid:required}/publications/{count:int}",
+        app.MapGet("/users/{userId:guid:required}/publications/count/{count:int}",
                 async (ISender sender, Guid userId, int count, Guid? lastPublicationId) =>
                 {
                     GetUserPublicationsQuery queryRequest =

--- a/social-campus-server/Presentation/Extensions/OpenApiExtension.cs
+++ b/social-campus-server/Presentation/Extensions/OpenApiExtension.cs
@@ -10,28 +10,42 @@ public class OpenApiExtension(IAuthenticationSchemeProvider authenticationScheme
         CancellationToken cancellationToken)
     {
         var authenticationSchemes = await authenticationSchemeProvider.GetAllSchemesAsync();
+
+        document.Components ??= new OpenApiComponents();
+        document.Components.SecuritySchemes ??= new Dictionary<string, OpenApiSecurityScheme>();
+
         if (authenticationSchemes.Any(authScheme => authScheme.Name == "Bearer"))
         {
-            var requirements = new Dictionary<string, OpenApiSecurityScheme>
+            document.Components.SecuritySchemes["Bearer"] = new OpenApiSecurityScheme
             {
-                ["Bearer"] = new()
-                {
-                    Type = SecuritySchemeType.Http,
-                    Scheme = "bearer",
-                    In = ParameterLocation.Header,
-                    BearerFormat = "Json Web Token"
-                }
+                Type = SecuritySchemeType.Http,
+                Scheme = "bearer",
+                In = ParameterLocation.Header,
+                BearerFormat = "JWT",
             };
-            document.Components ??= new OpenApiComponents();
-            document.Components.SecuritySchemes = requirements;
+
+            document.SecurityRequirements ??= [];
+            document.SecurityRequirements.Add(new OpenApiSecurityRequirement
+            {
+                {
+                    new OpenApiSecurityScheme
+                    {
+                        Reference = new OpenApiReference
+                        {
+                            Type = ReferenceType.SecurityScheme,
+                            Id = "Bearer"
+                        }
+                    },
+                    Array.Empty<string>()
+                }
+            });
         }
 
         document.Info = new OpenApiInfo
         {
             Title = "Social Campus API",
             Version = "v1",
-            Description =
-                "Comprehensive API for Social Campus platform, enabling seamless user interaction, content sharing, and community engagement."
+            Description = "Comprehensive API for Social Campus platform, enabling seamless user interaction, content sharing, and community engagement."
         };
     }
 }

--- a/social-campus-server/Presentation/Extensions/OpenApiExtension.cs
+++ b/social-campus-server/Presentation/Extensions/OpenApiExtension.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+
+namespace Presentation.Extensions;
+
+public class OpenApiExtension(IAuthenticationSchemeProvider authenticationSchemeProvider) : IOpenApiDocumentTransformer
+{
+    public async Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context,
+        CancellationToken cancellationToken)
+    {
+        var authenticationSchemes = await authenticationSchemeProvider.GetAllSchemesAsync();
+        if (authenticationSchemes.Any(authScheme => authScheme.Name == "Bearer"))
+        {
+            var requirements = new Dictionary<string, OpenApiSecurityScheme>
+            {
+                ["Bearer"] = new()
+                {
+                    Type = SecuritySchemeType.Http,
+                    Scheme = "bearer",
+                    In = ParameterLocation.Header,
+                    BearerFormat = "Json Web Token"
+                }
+            };
+            document.Components ??= new OpenApiComponents();
+            document.Components.SecuritySchemes = requirements;
+        }
+
+        document.Info = new OpenApiInfo
+        {
+            Title = "Social Campus API",
+            Version = "v1",
+            Description =
+                "Comprehensive API for Social Campus platform, enabling seamless user interaction, content sharing, and community engagement."
+        };
+    }
+}

--- a/social-campus-server/Presentation/Program.cs
+++ b/social-campus-server/Presentation/Program.cs
@@ -1,6 +1,11 @@
 using System.Reflection;
+using System.Text;
 using Application;
 using Infrastructure;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
+using Presentation;
 using Presentation.Extensions;
 using Scalar.AspNetCore;
 
@@ -8,17 +13,8 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
     .AddInfrastructure(builder.Configuration)
-    .AddApplication();
-
-builder.Services.AddOpenApi();
-builder.Services.AddEndpoints(Assembly.GetExecutingAssembly());
-builder.Services.AddClientCors(
-    "ClientCors",
-    [
-        "http://localhost:3000",
-        "https://localhost:3000"
-    ]
-);
+    .AddApplication()
+    .AddPresentation(builder.Configuration);
 
 var app = builder.Build();
 


### PR DESCRIPTION
### **Pull Request Title:**

**feat: implement fetching and displaying publications from followed and random users on homepage**

---

### **Description**

This pull request introduces full support for fetching and displaying publications from both followed users and random users on the Home page. It includes pagination, infinite scrolling, and backend support to provide a seamless and personalized user experience.

---

### **Related Issue**

Fixes #105 - Add fetching and displaying publications to home page from followed and random users.

---

### **Type of Change**

* [x] New feature
* [x] Bug fix
* [x] Refactor
* [ ] Breaking change
* [ ] Documentation update
* [ ] Other (please specify):

---

### **Proposed Changes**

* Implement `GetPublicationsForHomePageAsync` method with support for followed and random users
* Create `GetHomePagePublicationsQuery`, handler, validator, and endpoints
* Add `GetHomePagePublicationsByUserIdEndpoint` for user-specific requests
* Integrate pagination support using `lastPublication` logic
* Implement infinite scroll on Home and Profile components
* Refactor PublicationsList and fetching logic for efficiency and scalability
* Fix `CreatorId` handling and improve route naming
* Update `Profile` component to re-fetch data on login change
* Improve dependency injection and OpenAPI configuration

---

### **How to Test**

1. Login as a user who follows at least one other user
2. Navigate to the Home page
3. Scroll down — ensure more publications are loaded automatically
4. Check Profile page of a user and verify publications are paginated
5. Observe behavior if no followed users exist — random posts should load
6. Confirm proper response when revisiting Profile/Home page after login switch