### PR TITLE
Feat: Add pagination support to publication comments and replies

### DIFF
--- a/social-campus-client/src/components/recommendedProfiles/RecommendedProfiles.jsx
+++ b/social-campus-client/src/components/recommendedProfiles/RecommendedProfiles.jsx
@@ -3,6 +3,7 @@ import ShortProfile from "../shortProfile/ShortProfile";
 import "./RecommendedProfiles.css";
 import useAuth from "../../hooks/useAuth";
 import useAxiosPrivate from "../../hooks/useAxiosPrivate";
+import Loading from "../loading/Loading";
 
 const BASE_USER_URL = "/api/users";
 
@@ -32,7 +33,7 @@ function RecommendedProfiles() {
   }, [auth]);
 
   if (loading) {
-    return <h3 className="general-text">Loading recommendations...</h3>;
+    return <Loading />;
   }
 
   if (!recommendationList || recommendationList.length === 0) {

--- a/social-campus-server/Application/Comments/Queries/GetRepliesToComment/GetRepliesToCommentQuery.cs
+++ b/social-campus-server/Application/Comments/Queries/GetRepliesToComment/GetRepliesToCommentQuery.cs
@@ -4,4 +4,4 @@ using Domain.Models.CommentModel;
 
 namespace Application.Comments.Queries.GetRepliesToComment;
 
-public record GetRepliesToCommentQuery(CommentId CommentId) : IQuery<IReadOnlyList<CommentDto>>;
+public record GetRepliesToCommentQuery(CommentId CommentId, int Page, int Count) : IQuery<IReadOnlyList<CommentDto>>;

--- a/social-campus-server/Application/Comments/Queries/GetRepliesToComment/GetRepliesToCommentQueryHandler.cs
+++ b/social-campus-server/Application/Comments/Queries/GetRepliesToComment/GetRepliesToCommentQueryHandler.cs
@@ -17,7 +17,9 @@ public class GetRepliesToCommentQueryHandler(
                 "Comment.NotFound",
                 $"Comment with id {request.CommentId.Value} was not found"));
 
-        var comments = await commentRepository.GetRepliedCommentsByCommentIdAsync(request.CommentId);
+        var comments =
+            await commentRepository.GetPaginatedRepliedCommentsByCommentIdAsync(request.CommentId, request.Page,
+                request.Count);
 
         List<CommentDto> commentDtos = [];
         foreach (var c in comments)

--- a/social-campus-server/Application/Comments/Queries/GetRepliesToComment/GetRepliesToCommentQueryValidator.cs
+++ b/social-campus-server/Application/Comments/Queries/GetRepliesToComment/GetRepliesToCommentQueryValidator.cs
@@ -9,5 +9,15 @@ public class GetRepliesToCommentQueryValidator : AbstractValidator<GetRepliesToC
         RuleFor(x => x.CommentId)
             .NotNull().WithMessage("CommentId is required")
             .Must(id => id.Value != Guid.Empty).WithMessage("CommentId must be a valid GUID");
+
+        RuleFor(f => f.Page)
+            .GreaterThan(0)
+            .WithMessage("Count must be greater than 0.");
+
+        RuleFor(x => x.Count)
+            .GreaterThan(0)
+            .WithMessage("Count must be greater than 0.")
+            .LessThanOrEqualTo(100)
+            .WithMessage("Count must be 100 or less.");
     }
 }

--- a/social-campus-server/Application/Publications/Queries/GetPublicationComments/GetPublicationCommentsQuery.cs
+++ b/social-campus-server/Application/Publications/Queries/GetPublicationComments/GetPublicationCommentsQuery.cs
@@ -4,4 +4,5 @@ using Domain.Models.PublicationModel;
 
 namespace Application.Publications.Queries.GetPublicationComments;
 
-public record GetPublicationCommentsQuery(PublicationId PublicationId) : IQuery<IReadOnlyList<CommentDto>>;
+public record GetPublicationCommentsQuery(PublicationId PublicationId, int Page, int Count)
+    : IQuery<IReadOnlyList<CommentDto>>;

--- a/social-campus-server/Application/Publications/Queries/GetPublicationComments/GetPublicationCommentsQueryHandler.cs
+++ b/social-campus-server/Application/Publications/Queries/GetPublicationComments/GetPublicationCommentsQueryHandler.cs
@@ -20,7 +20,9 @@ public class GetPublicationCommentsQueryHandler(
                 "Publication.NotFound",
                 $"Publication with PublicationId {request.PublicationId.Value} was not found"));
 
-        var publicationComments = await commentRepository.GetPublicationCommentsByPublicationIdAsync(publication.Id);
+        var publicationComments =
+            await commentRepository.GetPaginatedPublicationCommentsByPublicationIdAsync(publication.Id, request.Page,
+                request.Count);
 
         var commentDtos = new List<CommentDto>();
         foreach (var comment in publicationComments)

--- a/social-campus-server/Application/Publications/Queries/GetPublicationComments/GetPublicationCommentsQueryValidator.cs
+++ b/social-campus-server/Application/Publications/Queries/GetPublicationComments/GetPublicationCommentsQueryValidator.cs
@@ -9,5 +9,15 @@ public class GetPublicationCommentsQueryValidator : AbstractValidator<GetPublica
         RuleFor(f => f.PublicationId)
             .NotEmpty().WithMessage("PublicationId is required")
             .Must(id => id.Value != Guid.Empty).WithMessage("PublicationId must be a valid GUID");
+
+        RuleFor(f => f.Page)
+            .GreaterThan(0)
+            .WithMessage("Count must be greater than 0.");
+
+        RuleFor(x => x.Count)
+            .GreaterThan(0)
+            .WithMessage("Count must be greater than 0.")
+            .LessThanOrEqualTo(100)
+            .WithMessage("Count must be 100 or less.");
     }
 }

--- a/social-campus-server/Domain/Abstractions/Repositories/ICommentRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/ICommentRepository.cs
@@ -16,6 +16,10 @@ public interface ICommentRepository
         int count);
 
     public Task<IReadOnlyList<Comment>> GetRepliedCommentsByCommentIdAsync(CommentId commentId);
+
+    public Task<IReadOnlyList<Comment>> GetPaginatedRepliedCommentsByCommentIdAsync(CommentId commentId, int page,
+        int count);
+
     public void Update(Comment comment, string description);
     public Task<Comment?> GetByIdAsync(CommentId commentId);
     public Task<bool> IsExistByIdAsync(CommentId commentId);

--- a/social-campus-server/Domain/Abstractions/Repositories/ICommentRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/ICommentRepository.cs
@@ -10,7 +10,11 @@ public interface ICommentRepository
         CommentId? replyToCommentId = null);
 
     public Task<IReadOnlyList<Comment>> GetPublicationCommentsByPublicationIdAsync(PublicationId publicationId);
-    public Task<int> GetPublicationCommentsCountByPublicationIdAsync(PublicationId publicationId);
+
+    public Task<IReadOnlyList<Comment>> GetPaginatedPublicationCommentsByPublicationIdAsync(PublicationId publicationId,
+        int page,
+        int count);
+
     public Task<IReadOnlyList<Comment>> GetRepliedCommentsByCommentIdAsync(CommentId commentId);
     public void Update(Comment comment, string description);
     public Task<Comment?> GetByIdAsync(CommentId commentId);

--- a/social-campus-server/Infrastructure/Repositories/CommentRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/CommentRepository.cs
@@ -64,6 +64,20 @@ public class CommentRepository(ApplicationDbContext context) : ICommentRepositor
             .ToListAsync();
     }
 
+    public async Task<IReadOnlyList<Comment>> GetPaginatedRepliedCommentsByCommentIdAsync(CommentId commentId, int page,
+        int count)
+    {
+        return await context.Comments
+            .Where(comment => comment.ReplyToCommentId == commentId)
+            .Include(comment => comment.Creator)
+            .Include(comment => comment.CommentLikes)
+            .AsSplitQuery()
+            .OrderBy(comment => comment.CreationDateTime)
+            .Skip((page - 1) * count)
+            .Take(count)
+            .ToListAsync();
+    }
+
     public async Task<bool> IsExistByIdAsync(CommentId commentId)
     {
         return await context.Comments.AnyAsync(u => u.Id == commentId);

--- a/social-campus-server/Presentation/Endpoints/Comments/GetRepliedCommentsByCommentId/GetRepliedCommentsByCommentIdEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Comments/GetRepliedCommentsByCommentId/GetRepliedCommentsByCommentIdEndpoint.cs
@@ -10,9 +10,10 @@ public class GetRepliedCommentsByCommentIdEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("comments/replies/{commentId:guid:required}", async (ISender sender, Guid commentId) =>
+        app.MapGet("comments/replies/{commentId:guid:required}/count/{count:int}/page/{page:int}", async (
+                ISender sender, Guid commentId, int count, int page) =>
             {
-                GetRepliesToCommentQuery queryRequest = new(new CommentId(commentId));
+                GetRepliesToCommentQuery queryRequest = new(new CommentId(commentId), page, count);
 
                 var response = await sender.Send(queryRequest);
 

--- a/social-campus-server/Presentation/Endpoints/Publications/GetPublicationComments/GetPublicationCommentsEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Publications/GetPublicationComments/GetPublicationCommentsEndpoint.cs
@@ -10,14 +10,15 @@ public class GetPublicationCommentsEndpoint : BaseEndpoint, IEndpoint
 {
     public void MapEndpoint(IEndpointRouteBuilder app)
     {
-        app.MapGet("publications/{publicationId:guid:required}/comments", async (ISender sender, Guid publicationId) =>
-            {
-                GetPublicationCommentsQuery queryRequest = new(new PublicationId(publicationId));
+        app.MapGet("publications/{publicationId:guid:required}/comments/count/{count:int}/page/{page:int}",
+                async (ISender sender, Guid publicationId, int count, int page) =>
+                {
+                    GetPublicationCommentsQuery queryRequest = new(new PublicationId(publicationId), page, count);
 
-                var response = await sender.Send(queryRequest);
+                    var response = await sender.Send(queryRequest);
 
-                return response.IsSuccess ? Results.Ok(response.Value) : HandleFailure(response);
-            })
+                    return response.IsSuccess ? Results.Ok(response.Value) : HandleFailure(response);
+                })
             .WithTags(EndpointTags.Publications)
             .RequireAuthorization();
     }


### PR DESCRIPTION
### Description

This pull request introduces pagination and lazy loading functionality for comments and their replies in the Social-Campus application. It addresses performance and user experience issues when loading large numbers of comments and replies all at once. The backend query methods for fetching comments and replies have been enhanced to support pagination, and the frontend components have been updated to implement lazy loading for replies.

---

### Related Issue

Fixes #108

---

### Type of Change

* [x] New feature
* [ ] Bug fix
* [ ] Breaking change
* [ ] Documentation update
* [ ] Other (please specify)

---

### Proposed Changes

* Implement pagination for retrieving publication comments (`GetPaginatedPublicationCommentsByPublicationIdAsync`).
* Add pagination support for fetching replies to comments (`GetRepliesToCommentQuery`).
* Enhance frontend components to lazily load comment replies with pagination.
* Refactor and optimize pagination logic in relevant backend methods.
* Improve loading experience in `RecommendedProfiles` and `PublicationDetail` components.

---

### How to Test

1. Open a publication detail page with many comments.
2. Scroll through comments and observe that only a limited number of comments load initially.
3. Expand comment replies and verify that replies load incrementally with a "Load more" option or automatic lazy loading.
4. Check that paginated loading works correctly without skipping or duplicating comments or replies.
5. Confirm no regressions in other comment-related functionalities.

---

### Additional Context

This PR improves the scalability of comment loading on publication pages and aims to reduce load times and bandwidth usage for users with large comment threads.