### PR TITLE
Add full email verification flow with token and resend functionality

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,15 @@ services:
     networks:
       - socialcampus-net
 
+  mailhog:
+    image: mailhog/mailhog
+    container_name: socialcampus-mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
+    networks:
+      - socialcampus-net
+
   minio:
     image: minio/minio
     container_name: socialcampus-minio
@@ -31,7 +40,7 @@ services:
     image: minio/mc
     depends_on:
       - minio
-    entrypoint: ["/bin/sh", "-c"]
+    entrypoint: [ "/bin/sh", "-c" ]
     command: |
       "
       until mc alias set localminio http://minio:9000 minioadmin minioadmin; do
@@ -52,6 +61,7 @@ services:
 
 networks:
   socialcampus-net:
+
 
 volumes:
   mssql_data:

--- a/social-campus-client/src/pages/signup/SignUp.jsx
+++ b/social-campus-client/src/pages/signup/SignUp.jsx
@@ -29,7 +29,9 @@ function SignUp() {
         password: password.trim(),
       });
 
-      toast("Your account has been successfully created! Welcome aboard!");
+      toast(
+        "Your account has been successfully created! Welcome aboard! Please check your email and verify your address to log in."
+      );
       navigate("/signin");
     } catch (error) {
       if (error.response) {

--- a/social-campus-server/Application/Abstractions/Email/IEmailService.cs
+++ b/social-campus-server/Application/Abstractions/Email/IEmailService.cs
@@ -1,0 +1,6 @@
+namespace Application.Abstractions.Email;
+
+public interface IEmailService
+{
+    public Task SendEmailAsync(string messageReceiver, string messageSubject, string messageBody);
+}

--- a/social-campus-server/Application/Abstractions/Email/IEmailService.cs
+++ b/social-campus-server/Application/Abstractions/Email/IEmailService.cs
@@ -2,5 +2,5 @@ namespace Application.Abstractions.Email;
 
 public interface IEmailService
 {
-    public Task SendEmailAsync(string messageReceiver, string messageSubject, string messageBody);
+    public Task SendEmailAsync(string messageReceiver, string messageSubject, string messageBody, bool isHtml);
 }

--- a/social-campus-server/Application/Abstractions/Email/IEmailVerificationLinkFactory.cs
+++ b/social-campus-server/Application/Abstractions/Email/IEmailVerificationLinkFactory.cs
@@ -1,0 +1,8 @@
+using Domain.Models.EmailVerificationTokenModel;
+
+namespace Application.Abstractions.Email;
+
+public interface IEmailVerificationLinkFactory
+{
+    public string? Create(EmailVerificationTokenId emailVerificationTokenId);
+}

--- a/social-campus-server/Application/Helpers/EmailTemplateHelpers.cs
+++ b/social-campus-server/Application/Helpers/EmailTemplateHelpers.cs
@@ -1,0 +1,128 @@
+namespace Application.Helpers;
+
+public static class EmailTemplateHelpers
+{
+    public static string GetVerifyEmailHtml(string firstName, string verificationLink)
+    {
+        return $$"""
+                 <!DOCTYPE html>
+                 <html lang="en">
+                 <head>
+                     <meta charset="UTF-8" />
+                     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                     <title>Verify Your Email</title>
+                     <style>
+                         @import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap");
+
+                         body {
+                             font-family: "Roboto", sans-serif;
+                             background-color: var(--background-color);
+                             margin: 0;
+                             padding: 0;
+                             color: var(--general-text-color);
+                         }
+
+                         :root {
+                             --background-color: #f6f8fa;
+                             --button-color: #b0b3b8;
+                             --secondary-text-color: #a0a3ab;
+                             --active-like-color: #8a8f99;
+                             --icon-panel-color: #6a687e;
+                             --general-text-color: #3a3a3a;
+                         }
+
+                         * {
+                             scroll-behavior: smooth;
+                         }
+
+                         .container {
+                             background-color: #ffffff;
+                             max-width: 600px;
+                             margin: 30px auto;
+                             padding: 40px;
+                             border-radius: 8px;
+                             box-shadow: 0 4px 10px rgba(0,0,0,0.1);
+                         }
+
+                         .brand-header {
+                             font-size: 40px;
+                             font-weight: 700;
+                             color: var(--general-text-color);
+                             margin-bottom: 30px;
+                             font-family: "Roboto", sans-serif;
+                             text-align: left;
+                         }
+
+                         h1 {
+                             color: var(--general-text-color);
+                             font-weight: 700;
+                             margin-bottom: 10px;
+                             text-align: left;
+                         }
+
+                         p {
+                             color: var(--secondary-text-color);
+                             line-height: 1.6;
+                             font-weight: 400;
+                             text-align: left;
+                             margin: 0 0 15px 0;
+                         }
+
+                         .btn-container {
+                             text-align: center;
+                             margin-top: 20px;
+                         }
+
+                         .btn {
+                             display: inline-block;
+                             padding: 12px 24px;
+                             background-color: var(--button-color);
+                             color: white;
+                             text-decoration: none;
+                             border-radius: 360px;
+                             cursor: pointer;
+                             font-family: "Roboto", sans-serif;
+                             transition: transform 0.3s ease, background-color 0.3s ease;
+                         }
+
+                         .btn:hover {
+                             background-color: var(--active-like-color);
+                             transform: scale(1.1);
+                         }
+
+                         .footer {
+                             margin-top: 40px;
+                             font-size: 12px;
+                             color: var(--secondary-text-color);
+                             text-align: center;
+                         }
+
+                         a {
+                             color: var(--secondary-text-color);
+                             text-decoration: none;
+                         }
+
+                         a:hover {
+                             text-decoration: none;
+                         }
+                     </style>
+                 </head>
+                 <body>
+                     <div class="container">
+                         <h1>Hello {{System.Net.WebUtility.HtmlEncode(firstName)}},</h1>
+                         <p>Thanks for registering on Social Campus. To finish setting up your account, please verify your email by clicking the button below.</p>
+
+                         <div class="btn-container">
+                             <a href="{{System.Net.WebUtility.HtmlEncode(verificationLink)}}" class="btn">Verify Email</a>
+                         </div>
+
+                         <div class="footer">
+                             <p>If you did not request this, you can safely ignore this email.</p>
+                             <p>&copy; 2025 Social Campus. All rights reserved.</p>
+                         </div>
+                     </div>
+                 </body>
+                 </html>
+                 """;
+    }
+}

--- a/social-campus-server/Application/Users/Commands/Login/LoginCommandHandler.cs
+++ b/social-campus-server/Application/Users/Commands/Login/LoginCommandHandler.cs
@@ -2,6 +2,7 @@
 using Application.Abstractions.Messaging;
 using Application.Abstractions.Security;
 using Application.Dtos;
+using Application.Helpers;
 using Domain.Abstractions.Repositories;
 using Domain.Shared;
 
@@ -39,7 +40,7 @@ public class LoginCommandHandler(
                     "Email.LinkGenerationFailed",
                     "Unable to generate email verification link"));
 
-            var messageBody = $"To verify your email address <a href='{verificationLink}'>click here</a>";
+            var messageBody = EmailTemplateHelpers.GetVerifyEmailHtml(user.FirstName, verificationLink);
             await emailService.SendEmailAsync(user.Email, "Resend Email Verification", messageBody, true);
 
             return Result.Failure<UserLoginRefreshDto>(new Error(

--- a/social-campus-server/Application/Users/Commands/Register/RegisterCommandHandler.cs
+++ b/social-campus-server/Application/Users/Commands/Register/RegisterCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Application.Abstractions.Email;
 using Application.Abstractions.Messaging;
 using Application.Abstractions.Security;
+using Application.Helpers;
 using Domain.Abstractions.Repositories;
 using Domain.Models.UserModel;
 using Domain.Shared;
@@ -41,7 +42,7 @@ public class RegisterCommandHandler(
                 "Email.LinkGenerationFailed",
                 "Unable to generate email verification link"));
 
-        var messageBody = $"To verify your email address <a href='{verificationLink}'>click here</a>";
+        var messageBody = EmailTemplateHelpers.GetVerifyEmailHtml(registeredUser.FirstName, verificationLink);
         await emailService.SendEmailAsync(request.Email, "Email verification for Social-Campus", messageBody, true);
 
         return Result.Success();

--- a/social-campus-server/Application/Users/Commands/Register/RegisterCommandHandler.cs
+++ b/social-campus-server/Application/Users/Commands/Register/RegisterCommandHandler.cs
@@ -2,6 +2,7 @@
 using Application.Abstractions.Messaging;
 using Application.Abstractions.Security;
 using Domain.Abstractions.Repositories;
+using Domain.Models.UserModel;
 using Domain.Shared;
 
 namespace Application.Users.Commands.Register;
@@ -9,7 +10,9 @@ namespace Application.Users.Commands.Register;
 public class RegisterCommandHandler(
     IUserRepository userRepository,
     IPasswordHasher passwordHasher,
-    IEmailService emailService) : ICommandHandler<RegisterCommand>
+    IEmailService emailService,
+    IEmailVerificationTokenRepository emailVerificationTokenRepository,
+    IEmailVerificationLinkFactory emailVerificationLinkFactory) : ICommandHandler<RegisterCommand>
 {
     public async Task<Result> Handle(RegisterCommand request, CancellationToken cancellationToken)
     {
@@ -27,10 +30,19 @@ public class RegisterCommandHandler(
 
         var passwordHash = await passwordHasher.HashAsync(request.Password);
 
-        await userRepository.AddAsync(request.Login, passwordHash, request.Email, request.FirstName, request.LastName);
+        var registeredUser = await userRepository.AddAsync(request.Login, passwordHash, request.Email,
+            request.FirstName, request.LastName);
 
-        await emailService.SendEmailAsync(request.Email, "Email verification for Social-Campus",
-            "To verify your email address click here");
+        var emailVerificationToken = await emailVerificationTokenRepository.AddAsync(registeredUser.Id);
+
+        var verificationLink = emailVerificationLinkFactory.Create(emailVerificationToken.Id);
+        if (verificationLink is null)
+            return Result.Failure(new Error(
+                "Email.LinkGenerationFailed",
+                "Unable to generate email verification link"));
+
+        var messageBody = $"To verify your email address <a href='{verificationLink}'>click here</a>";
+        await emailService.SendEmailAsync(request.Email, "Email verification for Social-Campus", messageBody, true);
 
         return Result.Success();
     }

--- a/social-campus-server/Application/Users/Commands/Register/RegisterCommandHandler.cs
+++ b/social-campus-server/Application/Users/Commands/Register/RegisterCommandHandler.cs
@@ -1,4 +1,5 @@
-﻿using Application.Abstractions.Messaging;
+﻿using Application.Abstractions.Email;
+using Application.Abstractions.Messaging;
 using Application.Abstractions.Security;
 using Domain.Abstractions.Repositories;
 using Domain.Shared;
@@ -7,7 +8,8 @@ namespace Application.Users.Commands.Register;
 
 public class RegisterCommandHandler(
     IUserRepository userRepository,
-    IPasswordHasher passwordHasher) : ICommandHandler<RegisterCommand>
+    IPasswordHasher passwordHasher,
+    IEmailService emailService) : ICommandHandler<RegisterCommand>
 {
     public async Task<Result> Handle(RegisterCommand request, CancellationToken cancellationToken)
     {
@@ -26,6 +28,9 @@ public class RegisterCommandHandler(
         var passwordHash = await passwordHasher.HashAsync(request.Password);
 
         await userRepository.AddAsync(request.Login, passwordHash, request.Email, request.FirstName, request.LastName);
+
+        await emailService.SendEmailAsync(request.Email, "Email verification for Social-Campus",
+            "To verify your email address click here");
 
         return Result.Success();
     }

--- a/social-campus-server/Application/Users/Commands/VerifyEmail/VerifyEmailCommand.cs
+++ b/social-campus-server/Application/Users/Commands/VerifyEmail/VerifyEmailCommand.cs
@@ -1,0 +1,6 @@
+using Application.Abstractions.Messaging;
+using Domain.Models.EmailVerificationTokenModel;
+
+namespace Application.Users.Commands.VerifyEmail;
+
+public record VerifyEmailCommand(EmailVerificationTokenId EmailVerificationTokenId) : ICommand;

--- a/social-campus-server/Application/Users/Commands/VerifyEmail/VerifyEmailCommandHandler.cs
+++ b/social-campus-server/Application/Users/Commands/VerifyEmail/VerifyEmailCommandHandler.cs
@@ -1,0 +1,44 @@
+using Application.Abstractions.Messaging;
+using Domain.Abstractions.Repositories;
+using Domain.Shared;
+
+namespace Application.Users.Commands.VerifyEmail;
+
+public class VerifyEmailCommandHandler(
+    IEmailVerificationTokenRepository verificationTokenRepository,
+    IUserRepository userRepository)
+    : ICommandHandler<VerifyEmailCommand>
+{
+    public async Task<Result> Handle(VerifyEmailCommand request, CancellationToken cancellationToken)
+    {
+        var emailVerificationToken = await verificationTokenRepository.GetAsync(request.EmailVerificationTokenId);
+        if (emailVerificationToken is null)
+            return Result.Failure(new Error(
+                "EmailVerificationToken.NotFound",
+                $"EmailVerificationToken with id {request.EmailVerificationTokenId.Value} was not found"));
+
+        if (emailVerificationToken.ExpiresOnUtc < DateTime.UtcNow)
+        {
+            verificationTokenRepository.Remove(emailVerificationToken);
+            return Result.Failure(new Error(
+                "EmailVerificationToken.Expired",
+                "The email verification token has expired"));
+        }
+
+        var user = await userRepository.GetByIdAsync(emailVerificationToken.UserId);
+        if (user is null)
+            return Result.Failure(new Error(
+                "User.NotFound",
+                $"User with id {emailVerificationToken.UserId.Value} was not found"));
+
+        if (user.IsEmailVerified)
+            return Result.Failure(new Error(
+                "User.AlreadyVerified",
+                $"User with id {emailVerificationToken.UserId.Value} has already verified their email"));
+
+        userRepository.MakeUserEmailVarified(user);
+        verificationTokenRepository.Remove(emailVerificationToken);
+
+        return Result.Success();
+    }
+}

--- a/social-campus-server/Application/Users/Commands/VerifyEmail/VerifyEmailCommandValidator.cs
+++ b/social-campus-server/Application/Users/Commands/VerifyEmail/VerifyEmailCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Application.Users.Commands.VerifyEmail;
+
+public class VerifyEmailCommandValidator : AbstractValidator<VerifyEmailCommand>
+{
+    public VerifyEmailCommandValidator()
+    {
+        RuleFor(f => f.EmailVerificationTokenId)
+            .NotEmpty().WithMessage("EmailVerificationTokenId is required")
+            .Must(id => id.Value != Guid.Empty).WithMessage("EmailVerificationTokenId must be a valid GUID");
+    }
+}

--- a/social-campus-server/Domain/Abstractions/Repositories/IEmailVerificationTokenRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IEmailVerificationTokenRepository.cs
@@ -6,6 +6,6 @@ namespace Domain.Abstractions.Repositories;
 public interface IEmailVerificationTokenRepository
 {
     public Task<EmailVerificationToken?> GetAsync(EmailVerificationTokenId id);
-    public Task AddAsync(UserId userEmailToVerifyId);
+    public Task<EmailVerificationToken> AddAsync(UserId userEmailToVerifyId);
     public void Remove(EmailVerificationToken token);
 }

--- a/social-campus-server/Domain/Abstractions/Repositories/IEmailVerificationTokenRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IEmailVerificationTokenRepository.cs
@@ -1,0 +1,11 @@
+using Domain.Models.EmailVerificationTokenModel;
+using Domain.Models.UserModel;
+
+namespace Domain.Abstractions.Repositories;
+
+public interface IEmailVerificationTokenRepository
+{
+    public Task<EmailVerificationToken?> GetAsync(EmailVerificationTokenId id);
+    public Task AddAsync(UserId userEmailToVerifyId);
+    public void Remove(EmailVerificationToken token);
+}

--- a/social-campus-server/Domain/Abstractions/Repositories/IUserRepository.cs
+++ b/social-campus-server/Domain/Abstractions/Repositories/IUserRepository.cs
@@ -7,7 +7,7 @@ public interface IUserRepository
 {
     public Task<bool> IsEmailUniqueAsync(string email);
     public Task<bool> IsLoginUniqueAsync(string login);
-    public Task AddAsync(string login, string passwordHash, string email, string firstName, string lastName);
+    public Task<User> AddAsync(string login, string passwordHash, string email, string firstName, string lastName);
     public Task<User?> GetByEmailAsync(string email);
     public Task<User?> GetByLoginAsync(string login);
     public Task<User?> GetByIdAsync(UserId id);
@@ -20,4 +20,5 @@ public interface IUserRepository
 
     public Task<IReadOnlyList<User>> SearchAsync(string searchTerm, int page, int count);
     public Task DeleteAsync(User user);
+    public void MakeUserEmailVarified(User user);
 }

--- a/social-campus-server/Domain/Consts/VerifyConsts.cs
+++ b/social-campus-server/Domain/Consts/VerifyConsts.cs
@@ -1,0 +1,6 @@
+namespace Domain.Consts;
+
+public static class VerifyConsts
+{
+    public const string VerifyEmail = "VerifyEmail";
+}

--- a/social-campus-server/Domain/Models/EmailVerificationTokenModel/EmailVerificationToken.cs
+++ b/social-campus-server/Domain/Models/EmailVerificationTokenModel/EmailVerificationToken.cs
@@ -1,0 +1,24 @@
+using Domain.Models.UserModel;
+
+namespace Domain.Models.EmailVerificationTokenModel;
+
+public class EmailVerificationToken
+{
+    private EmailVerificationToken()
+    {
+    }
+
+    public EmailVerificationToken(UserId userId, int expirationInSeconds)
+    {
+        Id = new EmailVerificationTokenId(Guid.NewGuid());
+        UserId = userId;
+        CreatedOnUtc = DateTime.UtcNow;
+        ExpiresOnUtc = DateTime.UtcNow.AddSeconds(expirationInSeconds);
+    }
+
+    public EmailVerificationTokenId Id { get; private set; } = new(Guid.Empty);
+    public UserId UserId { get; private set; } = new(Guid.Empty);
+    public DateTime CreatedOnUtc { get; private set; }
+    public DateTime ExpiresOnUtc { get; private set; }
+    public virtual User? User { get; }
+}

--- a/social-campus-server/Domain/Models/EmailVerificationTokenModel/EmailVerificationTokenId.cs
+++ b/social-campus-server/Domain/Models/EmailVerificationTokenModel/EmailVerificationTokenId.cs
@@ -1,0 +1,3 @@
+namespace Domain.Models.EmailVerificationTokenModel;
+
+public record EmailVerificationTokenId(Guid Value);

--- a/social-campus-server/Domain/Models/UserModel/User.cs
+++ b/social-campus-server/Domain/Models/UserModel/User.cs
@@ -1,5 +1,6 @@
 ﻿using Domain.Models.CommentLikeModel;
 using Domain.Models.CommentModel;
+using Domain.Models.EmailVerificationTokenModel;
 using Domain.Models.FollowModel;
 using Domain.Models.PublicationLikeModel;
 using Domain.Models.PublicationModel;
@@ -36,6 +37,7 @@ public class User
     public string LastName { get; private set; } = string.Empty;
     public string Bio { get; private set; } = string.Empty;
     public string ProfileImageUrl { get; private set; } = string.Empty;
+    public bool IsEmailVerified { get; private set; } = false;
     public RefreshTokenId RefreshTokenId { get; private set; } = new(Guid.Empty);
     public virtual RefreshToken? RefreshToken { get; }
     public virtual ICollection<Follow>? Followers { get; }
@@ -44,6 +46,7 @@ public class User
     public virtual ICollection<PublicationLike>? PublicationLikes { get; }
     public virtual ICollection<Comment>? Comments { get; }
     public virtual ICollection<CommentLike>? CommentLikes { get; }
+    public virtual ICollection<EmailVerificationToken>? EmailVerificationTokens { get; }
 
     public void SetRefreshTokenId(RefreshTokenId refreshTokenId)
     {
@@ -69,5 +72,10 @@ public class User
     public void UpdatePasswordHash(string passwordHash)
     {
         PasswordHash = passwordHash;
+    }
+
+    public void MakeEmailVerified()
+    {
+        IsEmailVerified = true;
     }
 }

--- a/social-campus-server/Infrastructure/Configurations/EmailVerificationTokenConfiguration.cs
+++ b/social-campus-server/Infrastructure/Configurations/EmailVerificationTokenConfiguration.cs
@@ -1,0 +1,35 @@
+using Domain.Models.EmailVerificationTokenModel;
+using Domain.Models.UserModel;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Infrastructure.Configurations;
+
+public class EmailVerificationTokenConfiguration : IEntityTypeConfiguration<EmailVerificationToken>
+{
+    public void Configure(EntityTypeBuilder<EmailVerificationToken> builder)
+    {
+        builder.HasKey(vt => vt.Id);
+
+        builder.Property(vt => vt.Id)
+            .HasConversion(userId => userId.Value, value => new EmailVerificationTokenId(value))
+            .IsRequired();
+
+        builder.Property(vt => vt.UserId)
+            .HasConversion(userId => userId.Value, value => new UserId(value))
+            .IsRequired();
+
+        builder.Property(vt => vt.CreatedOnUtc)
+            .IsRequired();
+
+        builder.Property(vt => vt.ExpiresOnUtc)
+            .IsRequired();
+
+        builder.HasIndex(vt => vt.Id).IsUnique();
+        builder.HasIndex(vt => vt.UserId);
+
+        builder.HasOne(vt => vt.User)
+            .WithMany(u => u.EmailVerificationTokens)
+            .HasForeignKey(vt => vt.UserId);
+    }
+}

--- a/social-campus-server/Infrastructure/Data/ApplicationDbContext.cs
+++ b/social-campus-server/Infrastructure/Data/ApplicationDbContext.cs
@@ -1,5 +1,6 @@
 ﻿using Domain.Models.CommentLikeModel;
 using Domain.Models.CommentModel;
+using Domain.Models.EmailVerificationTokenModel;
 using Domain.Models.FollowModel;
 using Domain.Models.PublicationLikeModel;
 using Domain.Models.PublicationModel;
@@ -22,6 +23,7 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public required DbSet<CommentLike> CommentLikes { get; set; }
     public required DbSet<Tag> Tags { get; set; }
     public required DbSet<PublicationTag> PublicationTags { get; set; }
+    public required DbSet<EmailVerificationToken> EmailVerificationTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/social-campus-server/Infrastructure/DependencyInjection.cs
+++ b/social-campus-server/Infrastructure/DependencyInjection.cs
@@ -34,6 +34,7 @@ public static class DependencyInjection
         services.AddScoped<ICommentLikeRepository, CommentLikeRepository>();
         services.AddScoped<ITagRepository, TagRepository>();
         services.AddScoped<IPublicationTagRepository, PublicationTagRepository>();
+        services.AddScoped<IEmailVerificationTokenRepository, EmailVerificationTokenRepository>();
 
         services.AddSingleton<IJwtProvider, JwtProvider>();
 

--- a/social-campus-server/Infrastructure/DependencyInjection.cs
+++ b/social-campus-server/Infrastructure/DependencyInjection.cs
@@ -1,8 +1,10 @@
 ﻿using Application.Abstractions.Data;
+using Application.Abstractions.Email;
 using Application.Abstractions.Security;
 using Application.Abstractions.Storage;
 using Domain.Abstractions.Repositories;
 using Infrastructure.Data;
+using Infrastructure.Email;
 using Infrastructure.Repositories;
 using Infrastructure.Security;
 using Infrastructure.Storage;
@@ -36,6 +38,9 @@ public static class DependencyInjection
         services.AddSingleton<IJwtProvider, JwtProvider>();
 
         services.AddSingleton<IStorageService, MinioStorageService>();
+
+        services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
+        services.AddScoped<IEmailService, EmailService>();
 
         return services;
     }

--- a/social-campus-server/Infrastructure/DependencyInjection.cs
+++ b/social-campus-server/Infrastructure/DependencyInjection.cs
@@ -42,6 +42,8 @@ public static class DependencyInjection
 
         services.Configure<EmailSettings>(configuration.GetSection("EmailSettings"));
         services.AddScoped<IEmailService, EmailService>();
+        services.AddScoped<IEmailVerificationLinkFactory, EmailVerificationLinkFactory>();
+        services.AddHttpContextAccessor();
 
         return services;
     }

--- a/social-campus-server/Infrastructure/Email/EmailService.cs
+++ b/social-campus-server/Infrastructure/Email/EmailService.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using System.Net.Mail;
+using System.Text;
 using System.Threading.Tasks;
 using Application.Abstractions.Email;
 using Microsoft.Extensions.Options;
@@ -13,25 +14,23 @@ public class EmailService(IOptions<EmailSettings> options) : IEmailService
     private readonly string _smtpUser = options.Value.SmtpUser;
     private readonly string _smtpPass = options.Value.SmtpPass;
 
-    public async Task SendEmailAsync(string messageReceiver, string messageSubject, string messageBody)
+    public async Task SendEmailAsync(string messageReceiver, string messageSubject, string messageBody, bool isHtml)
     {
         using var mail = new MailMessage();
         mail.From = new MailAddress(string.IsNullOrEmpty(_smtpUser) ? "test@local.test" : _smtpUser);
-        mail.To.Add(messageReceiver);
         mail.Subject = messageSubject;
         mail.Body = messageBody;
+        mail.IsBodyHtml = isHtml;
+        mail.BodyEncoding = Encoding.UTF8;
+        mail.SubjectEncoding = Encoding.UTF8;
+
+        mail.To.Add(messageReceiver);
 
         using var smtp = new SmtpClient(_smtpHost, _smtpPort);
+        smtp.EnableSsl = !string.IsNullOrEmpty(_smtpUser) && !string.IsNullOrEmpty(_smtpPass);
 
         if (!string.IsNullOrEmpty(_smtpUser) && !string.IsNullOrEmpty(_smtpPass))
-        {
             smtp.Credentials = new NetworkCredential(_smtpUser, _smtpPass);
-            smtp.EnableSsl = true;
-        }
-        else
-        {
-            smtp.EnableSsl = false;
-        }
 
         await smtp.SendMailAsync(mail);
     }

--- a/social-campus-server/Infrastructure/Email/EmailService.cs
+++ b/social-campus-server/Infrastructure/Email/EmailService.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Net.Mail;
+using System.Threading.Tasks;
+using Application.Abstractions.Email;
+using Microsoft.Extensions.Options;
+
+namespace Infrastructure.Email;
+
+public class EmailService(IOptions<EmailSettings> options) : IEmailService
+{
+    private readonly string _smtpHost = options.Value.SmtpHost;
+    private readonly int _smtpPort = options.Value.SmtpPort;
+    private readonly string _smtpUser = options.Value.SmtpUser;
+    private readonly string _smtpPass = options.Value.SmtpPass;
+
+    public async Task SendEmailAsync(string messageReceiver, string messageSubject, string messageBody)
+    {
+        using var mail = new MailMessage();
+        mail.From = new MailAddress(string.IsNullOrEmpty(_smtpUser) ? "test@local.test" : _smtpUser);
+        mail.To.Add(messageReceiver);
+        mail.Subject = messageSubject;
+        mail.Body = messageBody;
+
+        using var smtp = new SmtpClient(_smtpHost, _smtpPort);
+
+        if (!string.IsNullOrEmpty(_smtpUser) && !string.IsNullOrEmpty(_smtpPass))
+        {
+            smtp.Credentials = new NetworkCredential(_smtpUser, _smtpPass);
+            smtp.EnableSsl = true;
+        }
+        else
+        {
+            smtp.EnableSsl = false;
+        }
+
+        await smtp.SendMailAsync(mail);
+    }
+}

--- a/social-campus-server/Infrastructure/Email/EmailSettings.cs
+++ b/social-campus-server/Infrastructure/Email/EmailSettings.cs
@@ -1,0 +1,9 @@
+namespace Infrastructure.Email;
+
+public class EmailSettings
+{
+    public string SmtpHost { get; init; } = string.Empty;
+    public int SmtpPort { get; init; }
+    public string SmtpUser { get; init; } = string.Empty;
+    public string SmtpPass { get; init; } = string.Empty;
+}

--- a/social-campus-server/Infrastructure/Email/EmailVerificationLinkFactory.cs
+++ b/social-campus-server/Infrastructure/Email/EmailVerificationLinkFactory.cs
@@ -1,0 +1,22 @@
+using Application.Abstractions.Email;
+using Domain.Consts;
+using Domain.Models.EmailVerificationTokenModel;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace Infrastructure.Email;
+
+public class EmailVerificationLinkFactory(IHttpContextAccessor httpContextAccessor, LinkGenerator linkGenerator)
+    : IEmailVerificationLinkFactory
+{
+    public string? Create(EmailVerificationTokenId emailVerificationTokenId)
+    {
+        var verificationLink =
+            linkGenerator.GetUriByName(
+                httpContextAccessor.HttpContext!,
+                VerifyConsts.VerifyEmail,
+                new { token = emailVerificationTokenId.Value });
+
+        return verificationLink;
+    }
+}

--- a/social-campus-server/Infrastructure/Repositories/EmailVerificationTokenRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/EmailVerificationTokenRepository.cs
@@ -1,0 +1,34 @@
+using Domain.Abstractions.Repositories;
+using Domain.Models.EmailVerificationTokenModel;
+using Domain.Models.UserModel;
+using Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Infrastructure.Repositories;
+
+public class EmailVerificationTokenRepository(ApplicationDbContext context) : IEmailVerificationTokenRepository
+{
+    private const int ExpirationInSeconds = 86400;
+
+    public async Task<EmailVerificationToken?> GetAsync(EmailVerificationTokenId id)
+    {
+        return await context.EmailVerificationTokens.FirstOrDefaultAsync(e => e.Id == id);
+    }
+
+    public async Task AddAsync(UserId userEmailToVerifyId)
+    {
+        var existingToken = await context.EmailVerificationTokens
+            .FirstOrDefaultAsync(t => t.UserId == userEmailToVerifyId);
+
+        if (existingToken != null)
+            context.EmailVerificationTokens.Remove(existingToken);
+
+        var token = new EmailVerificationToken(userEmailToVerifyId, ExpirationInSeconds);
+        await context.EmailVerificationTokens.AddAsync(token);
+    }
+
+    public void Remove(EmailVerificationToken token)
+    {
+        context.EmailVerificationTokens.Remove(token);
+    }
+}

--- a/social-campus-server/Infrastructure/Repositories/EmailVerificationTokenRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/EmailVerificationTokenRepository.cs
@@ -15,7 +15,7 @@ public class EmailVerificationTokenRepository(ApplicationDbContext context) : IE
         return await context.EmailVerificationTokens.FirstOrDefaultAsync(e => e.Id == id);
     }
 
-    public async Task AddAsync(UserId userEmailToVerifyId)
+    public async Task<EmailVerificationToken> AddAsync(UserId userEmailToVerifyId)
     {
         var existingToken = await context.EmailVerificationTokens
             .FirstOrDefaultAsync(t => t.UserId == userEmailToVerifyId);
@@ -25,6 +25,8 @@ public class EmailVerificationTokenRepository(ApplicationDbContext context) : IE
 
         var token = new EmailVerificationToken(userEmailToVerifyId, ExpirationInSeconds);
         await context.EmailVerificationTokens.AddAsync(token);
+
+        return token;
     }
 
     public void Remove(EmailVerificationToken token)

--- a/social-campus-server/Infrastructure/Repositories/UserRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/UserRepository.cs
@@ -104,6 +104,9 @@ public class UserRepository(
         var follows = context.Follows.Where(f => f.UserId == user.Id || f.FollowedUserId == user.Id);
         context.Follows.RemoveRange(follows);
 
+        var emailTokens = context.EmailVerificationTokens.Where(t => t.UserId == user.Id);
+        context.EmailVerificationTokens.RemoveRange(emailTokens);
+
         var refreshToken = await context.RefreshTokens.FirstOrDefaultAsync(rt => rt.UserId == user.Id);
         if (refreshToken != null)
             context.RefreshTokens.Remove(refreshToken);

--- a/social-campus-server/Infrastructure/Repositories/UserRepository.cs
+++ b/social-campus-server/Infrastructure/Repositories/UserRepository.cs
@@ -11,10 +11,12 @@ public class UserRepository(
     IPublicationRepository publicationRepository,
     ICommentRepository commentRepository) : IUserRepository
 {
-    public async Task AddAsync(string login, string passwordHash, string email, string firstName, string lastName)
+    public async Task<User> AddAsync(string login, string passwordHash, string email, string firstName, string lastName)
     {
         User newUser = new(login, passwordHash, email, firstName, lastName);
         await context.Users.AddAsync(newUser);
+
+        return newUser;
     }
 
     public async Task<User?> GetByEmailAsync(string email)
@@ -112,5 +114,11 @@ public class UserRepository(
             context.RefreshTokens.Remove(refreshToken);
 
         context.Users.Remove(user);
+    }
+
+    public void MakeUserEmailVarified(User user)
+    {
+        user.MakeEmailVerified();
+        context.Users.Update(user);
     }
 }

--- a/social-campus-server/Presentation/DependencyInjection.cs
+++ b/social-campus-server/Presentation/DependencyInjection.cs
@@ -10,6 +10,7 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddPresentation(this IServiceCollection services, IConfiguration configuration)
     {
+        services.AddRazorPages();
         services.AddAuthorization();
         services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
             .AddJwtBearer(o => o.TokenValidationParameters = new TokenValidationParameters

--- a/social-campus-server/Presentation/Endpoints/Users/VerifyEmail/VerifyEmailEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Users/VerifyEmail/VerifyEmailEndpoint.cs
@@ -1,0 +1,25 @@
+using Application.Users.Commands.VerifyEmail;
+using Domain.Consts;
+using Domain.Models.EmailVerificationTokenModel;
+using MediatR;
+using Presentation.Abstractions;
+using Presentation.Consts;
+
+namespace Presentation.Endpoints.Users.VerifyEmail;
+
+public class VerifyEmailEndpoint : BaseEndpoint, IEndpoint
+{
+    public void MapEndpoint(IEndpointRouteBuilder app)
+    {
+        app.MapGet("users/verify-email", async (ISender sender, Guid token) =>
+            {
+                var commandRequest = new VerifyEmailCommand(new EmailVerificationTokenId(token));
+
+                var response = await sender.Send(commandRequest);
+
+                return response.IsSuccess ? Results.Ok() : HandleFailure(response);
+            })
+            .WithTags(EndpointTags.Users)
+            .WithName(VerifyConsts.VerifyEmail);
+    }
+}

--- a/social-campus-server/Presentation/Endpoints/Users/VerifyEmail/VerifyEmailEndpoint.cs
+++ b/social-campus-server/Presentation/Endpoints/Users/VerifyEmail/VerifyEmailEndpoint.cs
@@ -17,7 +17,10 @@ public class VerifyEmailEndpoint : BaseEndpoint, IEndpoint
 
                 var response = await sender.Send(commandRequest);
 
-                return response.IsSuccess ? Results.Ok() : HandleFailure(response);
+                if (response.IsSuccess) return Results.Redirect("/VerifyEmailSuccess");
+
+                var errorMsg = Uri.EscapeDataString(response.Error.Message);
+                return Results.Redirect($"/VerifyEmailFailed?error={errorMsg}");
             })
             .WithTags(EndpointTags.Users)
             .WithName(VerifyConsts.VerifyEmail);

--- a/social-campus-server/Presentation/Pages/Shared/_Layout.cshtml
+++ b/social-campus-server/Presentation/Pages/Shared/_Layout.cshtml
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>@ViewData["Title"] - Social Campus</title>
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="~/css/styles.css" rel="stylesheet"/>
+</head>
+<body>
+@RenderBody()
+</body>
+</html>

--- a/social-campus-server/Presentation/Pages/VerifyEmailFailed.cshtml
+++ b/social-campus-server/Presentation/Pages/VerifyEmailFailed.cshtml
@@ -1,0 +1,26 @@
+@page
+@model Presentation.Pages.VerifyEmailFailed
+@{
+    ViewData["Title"] = "Email Verification Failed";
+    Layout = "_Layout";
+}
+
+<div class="container">
+    <h1>Social Campus</h1>
+    <h1>Email Verification Failed</h1>
+
+    @if (!string.IsNullOrWhiteSpace(Model.Error))
+    {
+        <p class="error-message">@Model.Error</p>
+    }
+    else
+    {
+        <p class="error-message">We're sorry, but the email verification failed due to an unknown error.</p>
+    }
+
+    <p>You may now safely close this page.</p>
+
+    <div class="footer">
+        &copy; @DateTime.Now.Year Social Campus. All rights reserved.
+    </div>
+</div>

--- a/social-campus-server/Presentation/Pages/VerifyEmailFailed.cshtml.cs
+++ b/social-campus-server/Presentation/Pages/VerifyEmailFailed.cshtml.cs
@@ -1,0 +1,14 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace Presentation.Pages;
+
+public class VerifyEmailFailed : PageModel
+{
+    public string? Error { get; set; }
+
+    public void OnGet(string? error = null)
+    {
+        Error = error;
+    }
+}

--- a/social-campus-server/Presentation/Pages/VerifyEmailSuccess.cshtml
+++ b/social-campus-server/Presentation/Pages/VerifyEmailSuccess.cshtml
@@ -1,0 +1,16 @@
+@page
+@{
+    ViewData["Title"] = "Email Verified Successfully";
+    Layout = "_Layout";
+}
+
+<div class="container">
+    <h1>Welcome to Social Campus!</h1>
+    <h1>Email Verified Successfully</h1>
+    <p class="success-message">Your email has been successfully verified. You can now log in.</p>
+    <p>You may now safely close this page.</p>
+
+    <div class="footer">
+        &copy; @DateTime.Now.Year Social Campus. All rights reserved.
+    </div>
+</div>

--- a/social-campus-server/Presentation/Program.cs
+++ b/social-campus-server/Presentation/Program.cs
@@ -27,6 +27,9 @@ if (app.Environment.IsDevelopment())
     await app.EnsureDatabaseCreatedAsync();
 }
 
+app.UseStaticFiles();
+app.MapRazorPages();
+
 app.UseHttpsRedirection();
 
 app.UseCors("ClientCors");

--- a/social-campus-server/Presentation/appsettings.Development.json
+++ b/social-campus-server/Presentation/appsettings.Development.json
@@ -21,5 +21,11 @@
     "AccessTokenExpirationInSeconds": 60,
     "RefreshTokenExpirationInSeconds": 259200,
     "SecretKey": "2011c5b16ac4c4f10f707741de3c3d7d71964d37ceb20596fa59c7e646c0562c8032cc4d03fde71aaf7ea9d8801301762338df57657193863c5e82a8980c811e83665867bc1920cd080e4cc98046f07ebef553c7cb03c56641358f374866a52e4328f02a06801f3d8fa1635de32f77515e01a588097171be5900952593ace6f4"
+  },
+  "EmailSettings": {
+    "SmtpHost": "localhost",
+    "SmtpPort": 1025,
+    "SmtpUser": "",
+    "SmtpPass": ""
   }
 }

--- a/social-campus-server/Presentation/wwwroot/css/styles.css
+++ b/social-campus-server/Presentation/wwwroot/css/styles.css
@@ -1,0 +1,58 @@
+:root {
+    --background-color: #f6f8fa;
+    --button-color: #b0b3b8;
+    --secondary-text-color: #a0a3ab;
+    --active-like-color: #8a8f99;
+    --icon-panel-color: #6a687e;
+    --general-text-color: #3a3a3a;
+}
+
+body {
+    font-family: "Roboto", sans-serif;
+    background-color: var(--background-color);
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 600px;
+    background: white;
+    padding: 40px;
+    border-radius: 10px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    text-align: center;
+}
+
+h1 {
+    color: var(--general-text-color);
+    font-size: 32px;
+    margin-bottom: 16px;
+}
+
+p {
+    color: var(--secondary-text-color);
+    font-size: 18px;
+    margin: 10px 0;
+}
+
+.error-message {
+    color: #d32f2f;
+    font-weight: 500;
+    margin-top: 10px;
+}
+
+.success-message {
+    color: #2e7d32;
+    font-weight: 500;
+    margin-top: 10px;
+}
+
+.footer {
+    margin-top: 40px;
+    font-size: 14px;
+    color: var(--secondary-text-color);
+}


### PR DESCRIPTION
### Description

This pull request implements a complete email verification flow for new user registrations and login. It adds token generation, verification endpoints, and the ability to resend verification emails to users who attempt to log in but have not yet verified their email address. This helps ensure that only verified users can fully access the system and improves user experience by allowing easy resending of verification links.

### Related Issue

Fixes #109

### Type of Change

* [x] New feature
* [ ] Bug fix
* [ ] Breaking change
* [ ] Documentation update
* [ ] Other (please specify)

### Proposed Changes

* Implement email service to send verification emails during user registration
* Add email verification token functionality including generation, storage, and expiration
* Create API endpoints for verifying tokens and confirming user emails
* Enhance login process to check verification status and resend verification emails if necessary

### How to Test

1. Register a new user and check that a verification email is sent
2. Click the verification link and verify that the user's email status updates to verified
3. Attempt to log in with an unverified email and confirm that the system prompts to resend verification email
4. Verify that resending the verification email sends a new valid token to the user

### Additional Context

* Email sending is configured to use the existing SMTP service
* Verification tokens expire after a configurable period (e.g., 24 hours)
* Future improvements might include throttling resend attempts to avoid spam