### PR TITLE
Add auto migration action

### DIFF
--- a/.github/workflows/ef-migration.yml
+++ b/.github/workflows/ef-migration.yml
@@ -1,0 +1,46 @@
+name: Run EF-Migration on Merge
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install EF Core CLI tools globally
+        run: dotnet tool install --global dotnet-ef --version 9.*
+
+      - name: Add dotnet tools to PATH
+        run: echo "$HOME/.dotnet/tools" >> $GITHUB_PATH
+
+      - name: Restore dependencies
+        run: dotnet restore ./social-campus-server
+
+      - name: Build project
+        run: dotnet build ./social-campus-server --configuration Release
+
+      - name: Create migration bundle
+        run: dotnet ef migrations bundle \
+          --project ./social-campus-server/Infrastructure \
+          --startup-project ./social-campus-server/Presentation \
+          --output ./ef-bundle \
+          --runtime linux-x64 \
+          --configuration Release
+
+      - name: Make migration bundle executable
+        run: chmod +x ./ef-bundle
+
+      - name: Run migration bundle to update database
+        env:
+          CONNECTION_STRING: ${{ secrets.PROD_CONNECTION_STRING }}
+        run: ./ef-bundle --connection "$CONNECTION_STRING"

--- a/social-campus-server/Infrastructure/DependencyInjection.cs
+++ b/social-campus-server/Infrastructure/DependencyInjection.cs
@@ -15,6 +15,7 @@ using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 
 namespace Infrastructure;
@@ -23,12 +24,9 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services, IConfiguration configuration)
     {
-        services.Configure<HasherOptions>(configuration.GetSection("Hasher"));
-        services.AddSingleton<IHasher, Hasher>();
-
         services.AddDbContext<ApplicationDbContext>(options =>
             options.UseNpgsql(configuration.GetConnectionString("DefaultConnection"))
-                .UseAsyncSeeding(async (context, _, ct) => await DatabaseSeeder.SeedAsync(context, services, ct)));
+        );
 
         services.AddDataProtection()
             .PersistKeysToDbContext<ApplicationDbContext>()
@@ -44,6 +42,9 @@ public static class DependencyInjection
         services.AddScoped<ICommentLikeRepository, CommentLikeRepository>();
         services.AddScoped<ITagRepository, TagRepository>();
         services.AddScoped<IPublicationTagRepository, PublicationTagRepository>();
+        
+        services.Configure<HasherOptions>(configuration.GetSection("Hasher"));
+        services.AddSingleton<IHasher, Hasher>();
 
         services.Configure<EmailVerificationTokenOptions>(configuration.GetSection("EmailVerificationToken"));
         services.AddScoped<IEmailVerificationTokenRepository, EmailVerificationTokenRepository>();

--- a/social-campus-server/Infrastructure/Migrations/20250714223458_InitialCreate.Designer.cs
+++ b/social-campus-server/Infrastructure/Migrations/20250714223458_InitialCreate.Designer.cs
@@ -12,8 +12,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    [Migration("20250628161319_InitialMigration")]
-    partial class InitialMigration
+    [Migration("20250714223458_InitialCreate")]
+    partial class InitialCreate
     {
         /// <inheritdoc />
         protected override void BuildTargetModel(ModelBuilder modelBuilder)
@@ -168,7 +168,7 @@ namespace Infrastructure.Migrations
                         .HasMaxLength(1000)
                         .HasColumnType("character varying(1000)");
 
-                    b.Property<string>("ImageUrl")
+                    b.Property<string>("ImageObjectKey")
                         .HasColumnType("text");
 
                     b.HasKey("Id");
@@ -315,7 +315,7 @@ namespace Infrastructure.Migrations
                         .HasMaxLength(160)
                         .HasColumnType("character varying(160)");
 
-                    b.Property<string>("ProfileImageUrl")
+                    b.Property<string>("ProfileImageObjectKey")
                         .HasColumnType("text");
 
                     b.Property<Guid>("RefreshTokenId")

--- a/social-campus-server/Infrastructure/Migrations/20250714223458_InitialCreate.cs
+++ b/social-campus-server/Infrastructure/Migrations/20250714223458_InitialCreate.cs
@@ -7,7 +7,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Infrastructure.Migrations
 {
     /// <inheritdoc />
-    public partial class InitialMigration : Migration
+    public partial class InitialCreate : Migration
     {
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
@@ -64,7 +64,7 @@ namespace Infrastructure.Migrations
                     FirstName = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     LastName = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
                     Bio = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
-                    ProfileImageUrl = table.Column<string>(type: "text", nullable: true),
+                    ProfileImageObjectKey = table.Column<string>(type: "text", nullable: true),
                     RefreshTokenId = table.Column<Guid>(type: "uuid", nullable: false)
                 },
                 constraints: table =>
@@ -101,7 +101,7 @@ namespace Infrastructure.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: false),
-                    ImageUrl = table.Column<string>(type: "text", nullable: true),
+                    ImageObjectKey = table.Column<string>(type: "text", nullable: true),
                     CreationDateTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     CreatorId = table.Column<Guid>(type: "uuid", nullable: false)
                 },

--- a/social-campus-server/Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/social-campus-server/Infrastructure/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -165,7 +165,7 @@ namespace Infrastructure.Migrations
                         .HasMaxLength(1000)
                         .HasColumnType("character varying(1000)");
 
-                    b.Property<string>("ImageUrl")
+                    b.Property<string>("ImageObjectKey")
                         .HasColumnType("text");
 
                     b.HasKey("Id");
@@ -312,7 +312,7 @@ namespace Infrastructure.Migrations
                         .HasMaxLength(160)
                         .HasColumnType("character varying(160)");
 
-                    b.Property<string>("ProfileImageUrl")
+                    b.Property<string>("ProfileImageObjectKey")
                         .HasColumnType("text");
 
                     b.Property<Guid>("RefreshTokenId")

--- a/social-campus-server/Presentation/Extensions/DatabaseExtension.cs
+++ b/social-campus-server/Presentation/Extensions/DatabaseExtension.cs
@@ -1,13 +1,18 @@
 using Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
 
 namespace Presentation.Extensions;
 
 public static class DatabaseExtension
-{
-    public static async Task EnsureDatabaseCreatedAsync(this WebApplication app)
+{    
+    public static async Task MigrateAndSeedDatabaseAsync(this WebApplication app, IServiceCollection services,
+        CancellationToken cancellationToken = default)
     {
         await using var scope = app.Services.CreateAsyncScope();
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        await context.Database.EnsureCreatedAsync();
+        
+        await context.Database.MigrateAsync(cancellationToken);
+
+        await DatabaseSeeder.SeedAsync(context, services, cancellationToken);
     }
 }

--- a/social-campus-server/Presentation/Program.cs
+++ b/social-campus-server/Presentation/Program.cs
@@ -24,7 +24,7 @@ if (app.Environment.IsDevelopment())
             .AddPreferredSecuritySchemes("Bearer");
     });
 
-    await app.EnsureDatabaseCreatedAsync();
+    await app.MigrateAndSeedDatabaseAsync(builder.Services);
 }
 
 app.UseHttpsRedirection();


### PR DESCRIPTION
### Description

This pull request introduces an automatic migration GitHub Action to streamline the deployment workflow by running EF Core migrations automatically on merge. Additionally, the database seeding logic was revised to only seed the database in production environments, preventing unwanted seeding during development or testing.

### Type of Change

* [x] New feature (automatic migration GitHub Action)
* [x] Other (refactor seeding logic to run only in production)

### Proposed Changes

* Added a GitHub Action workflow to run EF Core migrations automatically on merges to the `main` branch.
* Refactored database seeding logic to only run in the production environment.
* Improved the deployment pipeline by automating migrations and controlling seeding behavior.

### How to Test

1. Merge this branch into `main`.
2. Verify that the GitHub Action runs the migrations successfully.
3. Confirm that the database seeding runs only in production (e.g., test locally or on staging that seeding does not run).
4. Check that the app runs without errors and the DB schema is up-to-date.

### Additional Context

Please ensure that the production connection string is properly configured in the GitHub repository secrets for the migration action to work correctly.